### PR TITLE
API Key DB 활용 방식 변경

### DIFF
--- a/inlol/src/main/java/dev/saariselka/inlol/Facade.java
+++ b/inlol/src/main/java/dev/saariselka/inlol/Facade.java
@@ -1,0 +1,4 @@
+package dev.saariselka.inlol;
+
+public class Facade {
+}

--- a/inlol/src/main/java/dev/saariselka/inlol/RestAPI.java
+++ b/inlol/src/main/java/dev/saariselka/inlol/RestAPI.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.saariselka.inlol.controller.APIController;
+import dev.saariselka.inlol.controller.APIKeyController;
 import dev.saariselka.inlol.service.APIService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.*;
@@ -26,6 +27,8 @@ public class RestAPI {
 
     @Autowired
     APIController apiController;
+    @Autowired
+    APIKeyController apiKeyController;
 
     @GetMapping("callAPI")
     public String callAPI() {
@@ -46,7 +49,7 @@ public class RestAPI {
         // 임시로 Petaluma,
         // api key는 만료되면 갱신해야 함
         String userID = "Petaluma";
-        String apiKey = "RGAPI-40229b42-021a-446c-80fe-f3a8776416ac";
+        String apiKey = apiKeyController.getAPIKey_ByCategory("Personal");
 
         // 1. puuid get
         String strPuuid = getPuuidByName(restTemplate, entity, userID, apiKey);

--- a/inlol/src/main/java/dev/saariselka/inlol/controller/APIController.java
+++ b/inlol/src/main/java/dev/saariselka/inlol/controller/APIController.java
@@ -17,7 +17,7 @@ import java.util.Optional;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping(path = "/test")
+@RequestMapping(path = "/api")
 public class APIController {
 
     private final Logger logger = LoggerFactory.getLogger(this.getClass());

--- a/inlol/src/main/java/dev/saariselka/inlol/controller/APIKeyController.java
+++ b/inlol/src/main/java/dev/saariselka/inlol/controller/APIKeyController.java
@@ -1,0 +1,46 @@
+package dev.saariselka.inlol.controller;
+
+import dev.saariselka.inlol.entity.APIKeyEntity;
+import dev.saariselka.inlol.service.APIKeyService;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(path = "/apikey")
+public class APIKeyController {
+
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    @Autowired
+    APIKeyService APIKeyService;
+
+    @GetMapping(produces = { MediaType.APPLICATION_JSON_VALUE })
+    public ResponseEntity<List<APIKeyEntity>> getAllkeys() {
+        List<APIKeyEntity> key = APIKeyService.findAll();
+        return new ResponseEntity<List<APIKeyEntity>>(key, HttpStatus.OK);
+    }
+
+    @GetMapping(value ="/{category}",produces = { MediaType.APPLICATION_JSON_VALUE })
+    public String getAPIKey_ByCategory(@PathVariable("category") String category) {
+        List<APIKeyEntity> keys = APIKeyService.findByCategory(category);
+
+        if(!keys.isEmpty()) {
+            return keys.get(0).getKey();
+        } else {
+            return null;
+        }
+    }
+
+}

--- a/inlol/src/main/java/dev/saariselka/inlol/controller/TeamController.java
+++ b/inlol/src/main/java/dev/saariselka/inlol/controller/TeamController.java
@@ -1,0 +1,47 @@
+package dev.saariselka.inlol.controller;
+
+import dev.saariselka.inlol.entity.TeamEntity;
+import dev.saariselka.inlol.service.TeamService;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(path = "/Team")
+public class TeamController {
+
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    @Autowired
+    TeamService TeamService;
+
+    @GetMapping(produces = { MediaType.APPLICATION_JSON_VALUE })
+    public ResponseEntity<List<TeamEntity>> getAllteams() {
+        List<TeamEntity> teams = TeamService.findAll();
+        return new ResponseEntity<List<TeamEntity>>(teams, HttpStatus.OK);
+    }
+
+    @GetMapping(value ="/{matchid}",produces = { MediaType.APPLICATION_JSON_VALUE })
+    public ResponseEntity<List<TeamEntity>> getTeams_ByMatchid(@PathVariable("matchid") String matchid) {
+        List<TeamEntity> teams = TeamService.findByMatchid(matchid);
+        return new ResponseEntity<List<TeamEntity>>(teams, HttpStatus.OK);
+    }
+
+    @GetMapping(value ="/{matchid,teamid}",produces = { MediaType.APPLICATION_JSON_VALUE })
+    public ResponseEntity<List<TeamEntity>> getTeams_ByMatchidAndTeamid(@PathVariable("matchid") String matchid,@PathVariable("teamid") int teamid) {
+        List<TeamEntity> teams = TeamService.findByMatchidAndTeamid(matchid,teamid);
+        return new ResponseEntity<List<TeamEntity>>(teams, HttpStatus.OK);
+    }
+
+}

--- a/inlol/src/main/java/dev/saariselka/inlol/entity/APIKeyEntity.java
+++ b/inlol/src/main/java/dev/saariselka/inlol/entity/APIKeyEntity.java
@@ -1,0 +1,26 @@
+package dev.saariselka.inlol.entity;
+
+import lombok.*;
+
+import javax.persistence.*;
+
+@Data
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+@Table(name="MST_KEY")
+public class APIKeyEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String category;
+    private String key;
+
+    public APIKeyEntity(String category, String key) {
+        this.category = category;
+        this.key = key;
+    }
+}

--- a/inlol/src/main/java/dev/saariselka/inlol/entity/TeamEntity.java
+++ b/inlol/src/main/java/dev/saariselka/inlol/entity/TeamEntity.java
@@ -1,0 +1,25 @@
+package dev.saariselka.inlol.entity;
+
+import lombok.*;
+
+import javax.persistence.*;
+
+@Data
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+@Table(name="RIOT_MATCH_TEAM")
+public class TeamEntity {
+    @Id
+    private String matchid;
+    private int teamid;
+
+    private boolean win;
+
+    public TeamEntity(String matchid, int teamid) {
+        this.matchid = matchid;
+        this.teamid = teamid;
+    }
+}

--- a/inlol/src/main/java/dev/saariselka/inlol/repository/APIKeyRepository.java
+++ b/inlol/src/main/java/dev/saariselka/inlol/repository/APIKeyRepository.java
@@ -1,0 +1,14 @@
+package dev.saariselka.inlol.repository;
+
+import dev.saariselka.inlol.entity.APIKeyEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface APIKeyRepository extends JpaRepository<APIKeyEntity, Long> {
+
+    public List<APIKeyEntity> findById(String id);
+    public List<APIKeyEntity> findByCategory(String category);
+}

--- a/inlol/src/main/java/dev/saariselka/inlol/repository/TeamRepository.java
+++ b/inlol/src/main/java/dev/saariselka/inlol/repository/TeamRepository.java
@@ -1,0 +1,15 @@
+package dev.saariselka.inlol.repository;
+
+import dev.saariselka.inlol.entity.APIKeyEntity;
+import dev.saariselka.inlol.entity.TeamEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface TeamRepository extends JpaRepository<TeamEntity, Long> {
+
+    public List<TeamEntity> findByMatchid(String matchid);
+    public List<TeamEntity> findByMatchidAndTeamid(String matchid, int teamid);
+}

--- a/inlol/src/main/java/dev/saariselka/inlol/service/APIKeyService.java
+++ b/inlol/src/main/java/dev/saariselka/inlol/service/APIKeyService.java
@@ -1,0 +1,37 @@
+package dev.saariselka.inlol.service;
+
+import dev.saariselka.inlol.entity.APIKeyEntity;
+import dev.saariselka.inlol.repository.APIKeyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class APIKeyService {
+
+    @Autowired
+    private final APIKeyRepository APIKeyRepository;
+
+    public List<APIKeyEntity> findAll() {
+        List<APIKeyEntity> keys = new ArrayList<>();
+        APIKeyRepository.findAll().forEach(e -> keys.add(e));
+
+        return keys;
+    }
+
+    public Optional<APIKeyEntity> findById(Long id) {
+        Optional<APIKeyEntity> key = APIKeyRepository.findById(id);
+        return key;
+    }
+
+    public List<APIKeyEntity> findByCategory(String category) {
+        List<APIKeyEntity> key = APIKeyRepository.findByCategory(category);
+        return key;
+    }
+
+}

--- a/inlol/src/main/java/dev/saariselka/inlol/service/TeamService.java
+++ b/inlol/src/main/java/dev/saariselka/inlol/service/TeamService.java
@@ -1,0 +1,36 @@
+package dev.saariselka.inlol.service;
+
+import dev.saariselka.inlol.entity.TeamEntity;
+import dev.saariselka.inlol.repository.TeamRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class TeamService {
+
+    @Autowired
+    private final TeamRepository TeamRepository;
+
+    public List<TeamEntity> findAll() {
+        List<TeamEntity> keys = new ArrayList<>();
+        TeamRepository.findAll().forEach(e -> keys.add(e));
+
+        return keys;
+    }
+
+    public List<TeamEntity> findByMatchid(String matchid) {
+        List<TeamEntity> key = TeamRepository.findByMatchid(matchid);
+        return key;
+    }
+
+    public List<TeamEntity> findByMatchidAndTeamid(String matchid, int teamid) {
+        List<TeamEntity> key = TeamRepository.findByMatchidAndTeamid(matchid, teamid);
+        return key;
+    }
+}


### PR DESCRIPTION
1. API Key DB 활용 방식으로 변경
2. RIOT_MATCH_TEAM 테이블 관련 JPA 파일 생성 ( entity, repository, service, controller )