### PR TITLE
Bot전 Spell 예외 처리, Participant PK 추가

### DIFF
--- a/inlol/src/main/java/dev/saariselka/inlol/controller/MatchParticipantController.java
+++ b/inlol/src/main/java/dev/saariselka/inlol/controller/MatchParticipantController.java
@@ -68,11 +68,12 @@ public class MatchParticipantController {
         return matchParticipantService.findByDataVersionAndMatchId(dataVersion, matchId);
     }
 
-    @GetMapping(value ="/{puuid,dataVersion,matchId}",produces = { MediaType.APPLICATION_JSON_VALUE })
+    @GetMapping(value ="/{puuid,dataVersion,matchId,chamionId}",produces = { MediaType.APPLICATION_JSON_VALUE })
     public List<MatchParticipantEntity> getMatchParticipant_ByMatchParticipantId(@PathVariable("puuid") String puuid
             ,@PathVariable("dataVersion") String dataVersion
-            ,@PathVariable("matchId") String matchId) {
-        return matchParticipantService.findById(new MatchParticipantId(puuid, dataVersion, matchId));
+            ,@PathVariable("matchId") String matchId
+            ,@PathVariable("championId") int championId) {
+        return matchParticipantService.findById(new MatchParticipantId(puuid, dataVersion, matchId, championId));
     }
 
     @GetMapping(value = "/{puuid}", produces = { MediaType.APPLICATION_JSON_VALUE })

--- a/inlol/src/main/java/dev/saariselka/inlol/dto/ParticipantDto.java
+++ b/inlol/src/main/java/dev/saariselka/inlol/dto/ParticipantDto.java
@@ -246,9 +246,17 @@ public class ParticipantDto {
         this.spell3Casts = String.valueOf(matchParticipantEntity.getSpell3Casts());
         this.spell4Casts = String.valueOf(matchParticipantEntity.getSpell4Casts());
         this.summoner1Casts = String.valueOf(matchParticipantEntity.getSummoner1Casts());
-        this.summoner1Id = String.valueOf(hashMapForSummonersData.get(matchParticipantEntity.getSummoner1Id()).get("full")).replaceAll("\"", "");
+        if(matchParticipantEntity.getSummoner1Id() != 0) {
+            this.summoner1Id = String.valueOf(hashMapForSummonersData.get(matchParticipantEntity.getSummoner1Id()).get("full")).replaceAll("\"", "");
+        } else {
+            this.summoner1Id = "bot";
+        }
         this.summoner2Casts = String.valueOf(matchParticipantEntity.getSummoner2Casts());
-        this.summoner2Id = String.valueOf(hashMapForSummonersData.get(matchParticipantEntity.getSummoner2Id()).get("full")).replaceAll("\"", "");
+        if(matchParticipantEntity.getSummoner2Id() != 0) {
+            this.summoner2Id = String.valueOf(hashMapForSummonersData.get(matchParticipantEntity.getSummoner2Id()).get("full")).replaceAll("\"", "");
+        } else {
+            this.summoner2Id = "bot";
+        }
         this.summonerId = matchParticipantEntity.getSummonerId();
         this.summonerLevel = String.valueOf(matchParticipantEntity.getSummonerLevel());
         this.summonerName = matchParticipantEntity.getSummonerName();

--- a/inlol/src/main/java/dev/saariselka/inlol/entity/MatchParticipantEntity.java
+++ b/inlol/src/main/java/dev/saariselka/inlol/entity/MatchParticipantEntity.java
@@ -19,7 +19,6 @@ public class MatchParticipantEntity {
     private int bountyLevel;
     private int champExperience;
     private int champLevel;
-    private int championId;
     private String championName;
     private int championTransform;
     private int consumablesPurchased;

--- a/inlol/src/main/java/dev/saariselka/inlol/entity/MatchParticipantId.java
+++ b/inlol/src/main/java/dev/saariselka/inlol/entity/MatchParticipantId.java
@@ -19,6 +19,8 @@ public class MatchParticipantId implements Serializable {
     private String dataVersion;
     @Column(nullable = false)
     private String matchId;
+    @Column(nullable = false)
+    private int championId;
 
     public MatchParticipantId(String dataVersion, String matchId) {
         this.dataVersion = dataVersion;

--- a/inlol/src/main/java/dev/saariselka/inlol/service/MatchParticipantService.java
+++ b/inlol/src/main/java/dev/saariselka/inlol/service/MatchParticipantService.java
@@ -48,8 +48,8 @@ public class MatchParticipantService {
                        int trueDamageTaken, int turretKills, int turretTakedowns, int turretsLost, int unrealKills, int visionScore, int visionWardsBoughtInGame,
                        int wardsKilled, int wardsPlaced, boolean win, Timestamp rrt) {
 
-        matchParticipantRepository.save(new MatchParticipantEntity(new MatchParticipantId(puuid, dataVersion, matchId), assists, baronKills,
-                bountyLevel, champExperience, champLevel, championId, championName, championTransform, consumablesPurchased, damageDealtToBuildings,
+        matchParticipantRepository.save(new MatchParticipantEntity(new MatchParticipantId(puuid, dataVersion, matchId, championId), assists, baronKills,
+                bountyLevel, champExperience, champLevel, championName, championTransform, consumablesPurchased, damageDealtToBuildings,
                 damageDealtToObjectives, damageDealtToTurrets, damageSelfMitigated, deaths, detectorWardsPlaced, doubleKills, dragonKills,
                 firstBloodAssist, firstBloodKill, firstTowerAssist, firstTowerKill, gameEndedInEarlySurrender, gameEndedInSurrender, goldEarned,
                 goldSpent, individualPosition, inhibitorKills, inhibitorTakedowns, inhibitorsLost, item0, item1, item2, item3, item4, item5, item6,

--- a/inlol/src/main/resources/templates/content/summoner.html
+++ b/inlol/src/main/resources/templates/content/summoner.html
@@ -136,12 +136,12 @@
                                     </div>
                                     <div class="spells">
                                         <div class="spell">
-                                            <div class="" style="position: relative;">
+                                            <div class="" style="position: relative;" th:if="${matchInfo.info.summoner.getSummoner1Id()} != 'bot'">
                                                 <img th:src="|http://ddragon.leagueoflegends.com/cdn/12.10.1/img/spell/${matchInfo.info.summoner.getSummoner1Id()}|">
                                             </div>
                                         </div>
                                         <div class="spell">
-                                            <div class="" style="position: relative;">
+                                            <div class="" style="position: relative;" th:if="${matchInfo.info.summoner.getSummoner2Id()} != 'bot'">
                                                 <img th:src="|http://ddragon.leagueoflegends.com/cdn/12.10.1/img/spell/${matchInfo.info.summoner.getSummoner2Id()}|">
                                             </div>
                                         </div>
@@ -278,8 +278,16 @@
                                         <img th:src="|https://ddragon.leagueoflegends.com/cdn/12.8.1/img/champion/${matchInfo.info.summoner.getChampionNameENG()}.png?image=q_auto&amp;image=q_auto,f_webp,w_auto&amp;v=1650634188774|" alt="${matchInfo.info.summoner.getChampionNameKR()}">
                                     </div>
                                     <div class="spells">
-                                        <div class="spell"><div class="" style="position: relative;"><img th:src="|http://ddragon.leagueoflegends.com/cdn/12.10.1/img/spell/${matchInfo.info.summoner.getSummoner1Id()}|"></div></div>
-                                        <div class="spell"><div class="" style="position: relative;"><img th:src="|http://ddragon.leagueoflegends.com/cdn/12.10.1/img/spell/${matchInfo.info.summoner.getSummoner2Id()}|"></div></div>
+                                        <div class="spell">
+                                            <div class="" style="position: relative;" th:if="${matchInfo.info.summoner.getSummoner1Id()} != 'bot'">
+                                                <img th:src="|http://ddragon.leagueoflegends.com/cdn/12.10.1/img/spell/${matchInfo.info.summoner.getSummoner1Id()}|">
+                                            </div>
+                                        </div>
+                                        <div class="spell">
+                                            <div class="" style="position: relative;" th:if="${matchInfo.info.summoner.getSummoner2Id()} != 'bot'">
+                                                <img th:src="|http://ddragon.leagueoflegends.com/cdn/12.10.1/img/spell/${matchInfo.info.summoner.getSummoner2Id()}|">
+                                            </div>
+                                        </div>
                                     </div>
                                     <div class="runes">
                                         <div class="rune">


### PR DESCRIPTION
1. MatchParticipant PK - championId 추가 관련 Controller, Entity, Service 수정
2. ParticipantDto 內 bot spell 인 경우, 예외처리 구문 추가
3. summoner.html 內 bot spell 인 경우, 예외처리 구문 추가