### PR TITLE
SummonerSpell DTO, VO 적용 관련 변경

### DIFF
--- a/inlol/src/main/java/dev/saariselka/inlol/controller/SummonerSpellController.java
+++ b/inlol/src/main/java/dev/saariselka/inlol/controller/SummonerSpellController.java
@@ -1,5 +1,7 @@
 package dev.saariselka.inlol.controller;
 
+import dev.saariselka.inlol.dto.DtoMapper;
+import dev.saariselka.inlol.dto.SummonerSpellDto;
 import dev.saariselka.inlol.entity.SummonerPerkEntity;
 import dev.saariselka.inlol.entity.SummonerSpellEntity;
 import dev.saariselka.inlol.service.SummonerSpellService;
@@ -20,16 +22,18 @@ public class SummonerSpellController {
 
     @Autowired
     SummonerSpellService summonerSpellService;
+    @Autowired
+    DtoMapper dtoMapper;
 
     public void insertSummonerSpell(String name, String description, int spellKey, String image) {
         summonerSpellService.insert(name, description, spellKey, image);
     }
 
-    public List<SummonerSpellEntity> getSummonerSpellByKey(int summonerSpellKey) {
-        return summonerSpellService.findByspellKey(summonerSpellKey);
+    public List<SummonerSpellDto> getSummonerSpellByKey(int summonerSpellKey) {
+        return dtoMapper.toSummonerSpellDtoList(summonerSpellService.findByspellKey(summonerSpellKey));
     }
 
-    public void insertAllSummonerSpell(List<SummonerSpellEntity> summonerSpellEntities) {
-        summonerSpellService.insertAll(summonerSpellEntities);
+    public void insertAllSummonerSpell(List<SummonerSpellDto> summonerSpellDtos) {
+        summonerSpellService.insertAll(dtoMapper.toSummonerSpellVOList(summonerSpellDtos));
     }
 }

--- a/inlol/src/main/java/dev/saariselka/inlol/dto/DtoMapper.java
+++ b/inlol/src/main/java/dev/saariselka/inlol/dto/DtoMapper.java
@@ -1,6 +1,7 @@
 package dev.saariselka.inlol.dto;
 
 import dev.saariselka.inlol.vo.ChampionVO;
+import dev.saariselka.inlol.vo.SummonerSpellVO;
 import lombok.NoArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -22,5 +23,27 @@ public class DtoMapper {
             voList.add(vo);
         }
         return voList;
+    }
+
+    public List<SummonerSpellVO> toSummonerSpellVOList(List<SummonerSpellDto> summonerSpellDtoList) {
+        List<SummonerSpellVO> summonerSpellVOList = new ArrayList<>();
+
+        for(SummonerSpellDto summonerSpell : summonerSpellDtoList) {
+            SummonerSpellVO summonerSpellVO = new SummonerSpellVO(summonerSpell.getName(),summonerSpell.getDescription(),summonerSpell.getSpellKey(),summonerSpell.getImage());
+            summonerSpellVOList.add(summonerSpellVO);
+        }
+
+        return summonerSpellVOList;
+    }
+
+    public List<SummonerSpellDto> toSummonerSpellDtoList(List<SummonerSpellVO> summonerSpellVOList) {
+        List<SummonerSpellDto> summonerSpellDtoList = new ArrayList<>();
+
+        for(SummonerSpellVO summonerSpell : summonerSpellVOList) {
+            SummonerSpellDto summonerSpellDto = new SummonerSpellDto(summonerSpell.getName(),summonerSpell.getDescription(),summonerSpell.getSpellKey(),summonerSpell.getImage());
+            summonerSpellDtoList.add(summonerSpellDto);
+        }
+
+        return summonerSpellDtoList;
     }
 }

--- a/inlol/src/main/java/dev/saariselka/inlol/dto/SummonerSpellDto.java
+++ b/inlol/src/main/java/dev/saariselka/inlol/dto/SummonerSpellDto.java
@@ -1,0 +1,16 @@
+package dev.saariselka.inlol.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class SummonerSpellDto {
+
+    private String name;
+    private String description;
+    private int spellKey;
+    private String image;
+}

--- a/inlol/src/main/java/dev/saariselka/inlol/facade/DBFacade.java
+++ b/inlol/src/main/java/dev/saariselka/inlol/facade/DBFacade.java
@@ -523,8 +523,8 @@ public class DBFacade {
         }
     }
 
-    public void setSummonerSpell(List<SummonerSpellEntity> summonerSpellEntities) {
-        summonerSpellController.insertAllSummonerSpell(summonerSpellEntities);
+    public void setSummonerSpell(List<SummonerSpellDto> summonerSpellDtos) {
+        summonerSpellController.insertAllSummonerSpell(summonerSpellDtos);
     }
 
     public void setChampions(List<ChampionDto> championEntities) {

--- a/inlol/src/main/java/dev/saariselka/inlol/facade/Facade_refactoring.java
+++ b/inlol/src/main/java/dev/saariselka/inlol/facade/Facade_refactoring.java
@@ -155,7 +155,7 @@ public class Facade_refactoring {
     private void initJsonResource() {
         JsonParserForLOL jsonParserForLOL = new JsonParserForLOL();
 
-        dbFacade.setSummonerSpell(jsonParserForLOL.getSummonerSpellEntities());
+        dbFacade.setSummonerSpell(jsonParserForLOL.getSummonerSpellDtoList());
         dbFacade.setChampions(jsonParserForLOL.getChampionEntities());
         dbFacade.setSummonerPerk(jsonParserForLOL.getSummonerPerkEntities());
     }

--- a/inlol/src/main/java/dev/saariselka/inlol/service/SummonerSpellService.java
+++ b/inlol/src/main/java/dev/saariselka/inlol/service/SummonerSpellService.java
@@ -2,6 +2,8 @@ package dev.saariselka.inlol.service;
 
 import dev.saariselka.inlol.entity.SummonerSpellEntity;
 import dev.saariselka.inlol.repository.SummonerSpellRepository;
+import dev.saariselka.inlol.vo.SummonerSpellVO;
+import dev.saariselka.inlol.vo.VOMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -13,16 +15,18 @@ import java.util.List;
 public class SummonerSpellService {
     @Autowired
     private final SummonerSpellRepository summonerSpellRepository;
+    @Autowired
+    private VOMapper voMapper;
 
     public void insert(String name, String description, int spellKey, String image) {
         summonerSpellRepository.save(new SummonerSpellEntity(name, description, spellKey, image));
     }
 
-    public List<SummonerSpellEntity> findByspellKey(int spellKey) {
-        return summonerSpellRepository.findByspellKey(spellKey);
+    public List<SummonerSpellVO> findByspellKey(int spellKey) {
+        return voMapper.toSummonerSpellVOList(summonerSpellRepository.findByspellKey(spellKey));
     }
 
-    public void insertAll(List<SummonerSpellEntity> summonerSpellEntities) {
-        summonerSpellRepository.saveAll(summonerSpellEntities);
+    public void insertAll(List<SummonerSpellVO> summonerSpellVOList) {
+        summonerSpellRepository.saveAll(voMapper.toSummonerSpellEntityList(summonerSpellVOList));
     }
 }

--- a/inlol/src/main/java/dev/saariselka/inlol/utils/JsonParserForLOL.java
+++ b/inlol/src/main/java/dev/saariselka/inlol/utils/JsonParserForLOL.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import dev.saariselka.inlol.controller.SummonerSpellController;
 import dev.saariselka.inlol.dto.ChampionDto;
+import dev.saariselka.inlol.dto.SummonerSpellDto;
 import dev.saariselka.inlol.entity.ChampionEntity;
 import dev.saariselka.inlol.entity.SummonerPerkEntity;
 import dev.saariselka.inlol.entity.SummonerSpellEntity;
@@ -53,9 +54,7 @@ public class JsonParserForLOL {
         return dtoList;
     }
 
-    public static String getSpellImageBySpellId(int spellId) {
-        if(spellId == 0) return "bot";
-
+    public List<SummonerSpellDto> getSummonerSpellDtoList() {
         ClassPathResource summonerResource = new ClassPathResource("json/summoner.json");
         JsonObject summonerJson = null;
 
@@ -68,30 +67,7 @@ public class JsonParserForLOL {
         JsonObject summonerJsonObject = (JsonObject) summonerJson.get("data");
         Set<String> keys = summonerJsonObject.keySet();
 
-        for(String key : keys) {
-            JsonObject summonerSpell = (JsonObject) summonerJsonObject.get(key);
-
-            if(spellId == summonerSpell.get("key").getAsInt()) {
-                return ((JsonObject) summonerSpell.get("image")).get("full").getAsString();
-            }
-        }
-
-        return null;
-    }
-    public List<SummonerSpellEntity> getSummonerSpellEntities() {
-        ClassPathResource summonerResource = new ClassPathResource("json/summoner.json");
-        JsonObject summonerJson = null;
-
-        try {
-            summonerJson = JsonParser.parseReader(new InputStreamReader(summonerResource.getInputStream(), StandardCharsets.UTF_8)).getAsJsonObject();
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-
-        JsonObject summonerJsonObject = (JsonObject) summonerJson.get("data");
-        Set<String> keys = summonerJsonObject.keySet();
-
-        List<SummonerSpellEntity> summonerSpellEntities = new ArrayList<>();
+        List<SummonerSpellDto> summonerSpellDtoList = new ArrayList<>();
 
         for(String key : keys) {
             JsonObject summonerSpell = (JsonObject) summonerJsonObject.get(key);
@@ -101,12 +77,12 @@ public class JsonParserForLOL {
             int spellKey = summonerSpell.get("key").getAsInt();
             String image = ((JsonObject) summonerSpell.get("image")).get("full").getAsString();
 
-            SummonerSpellEntity summonerSpellEntity = new SummonerSpellEntity(name, description, spellKey, image);
+            SummonerSpellDto summonerSpellDto = new SummonerSpellDto(name, description, spellKey, image);
 
-            summonerSpellEntities.add(summonerSpellEntity);
+            summonerSpellDtoList.add(summonerSpellDto);
         }
 
-        return summonerSpellEntities;
+        return summonerSpellDtoList;
     }
 
     public List<SummonerPerkEntity> getSummonerPerkEntities() {

--- a/inlol/src/main/java/dev/saariselka/inlol/vo/SummonerSpellVO.java
+++ b/inlol/src/main/java/dev/saariselka/inlol/vo/SummonerSpellVO.java
@@ -1,0 +1,17 @@
+package dev.saariselka.inlol.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SummonerSpellVO {
+    private String name;
+    private String description;
+    private int spellKey;
+    private String image;
+}

--- a/inlol/src/main/java/dev/saariselka/inlol/vo/VOMapper.java
+++ b/inlol/src/main/java/dev/saariselka/inlol/vo/VOMapper.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import dev.saariselka.inlol.entity.ChampionEntity;
 import dev.saariselka.inlol.entity.QueueTypeEntity;
+import dev.saariselka.inlol.entity.SummonerSpellEntity;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -46,5 +47,23 @@ public class VOMapper {
             entityList.add(entity);
         }
         return entityList;
+    }
+
+    public List<SummonerSpellVO> toSummonerSpellVOList(List<SummonerSpellEntity> summonerSpellEntities) {
+        List<SummonerSpellVO> summonerSpellVOList = new ArrayList<>();
+        for(SummonerSpellEntity summonerSpellEntity : summonerSpellEntities) {
+            SummonerSpellVO summonerSpellVO = new SummonerSpellVO(summonerSpellEntity.getName(), summonerSpellEntity.getDescription(), summonerSpellEntity.getSpellKey(), summonerSpellEntity.getImage());
+            summonerSpellVOList.add(summonerSpellVO);
+        }
+        return  summonerSpellVOList;
+    }
+
+    public List<SummonerSpellEntity> toSummonerSpellEntityList(List<SummonerSpellVO> summonerSpellVOList) {
+        List<SummonerSpellEntity> summonerSpellEntities = new ArrayList<>();
+        for(SummonerSpellVO summonerSpellVO : summonerSpellVOList) {
+            SummonerSpellEntity summonerSpellEntity = new SummonerSpellEntity(summonerSpellVO.getName(), summonerSpellVO.getDescription(), summonerSpellVO.getSpellKey(), summonerSpellVO.getImage());
+            summonerSpellEntities.add(summonerSpellEntity);
+        }
+        return  summonerSpellEntities;
     }
 }

--- a/inlol/src/test/java/dev/saariselka/inlol/controller/DtoMapperTest.java
+++ b/inlol/src/test/java/dev/saariselka/inlol/controller/DtoMapperTest.java
@@ -1,0 +1,68 @@
+package dev.saariselka.inlol.controller;
+
+import dev.saariselka.inlol.dto.DtoMapper;
+import dev.saariselka.inlol.dto.SummonerDto;
+import dev.saariselka.inlol.dto.SummonerSpellDto;
+import dev.saariselka.inlol.vo.SummonerSpellVO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DtoMapperTest {
+
+    @Autowired
+    DtoMapper dtoMapper;
+
+    @Test
+    @DisplayName("Convert SummonerSpellDtoList To SummonerSpellVOList")
+    public void toSummonerSpellVOList() {
+
+        //given
+        String name = "testSummonerSpellName";
+        String description = "testSummonerSpellDesc";
+        int spellKey = 0;
+        String image = "testSummonerSpellImage";
+        SummonerSpellDto summonerSpellDto = new SummonerSpellDto(name,description,spellKey,image);
+        List<SummonerSpellDto> summonerSpellDtoList = new ArrayList<>();
+        summonerSpellDtoList.add(summonerSpellDto);
+
+        //when
+        List<SummonerSpellVO> summonerSpellVOList = new ArrayList<>();
+        summonerSpellVOList = dtoMapper.toSummonerSpellVOList(summonerSpellDtoList);
+
+        //then
+        assertThat(summonerSpellVOList.get(0).getName()).isEqualTo(name);
+        assertThat(summonerSpellVOList.get(0).getDescription()).isEqualTo(description);
+        assertThat(summonerSpellVOList.get(0).getSpellKey()).isEqualTo(spellKey);
+        assertThat(summonerSpellVOList.get(0).getImage()).isEqualTo(image);
+    }
+
+    @Test
+    @DisplayName("Convert SummonerSpellVOList To SummonerSpellDtoList")
+    public void toSummonerSpellDtoList() {
+
+        //given
+        String name = "testSummonerSpellName";
+        String description = "testSummonerSpellDesc";
+        int spellKey = 0;
+        String image = "testSummonerSpellImage";
+        SummonerSpellVO summonerSpellVO = new SummonerSpellVO(name,description,spellKey,image);
+        List<SummonerSpellVO> summonerSpellVOList = new ArrayList<>();
+        summonerSpellVOList.add(summonerSpellVO);
+
+        //when
+        List<SummonerSpellDto> summonerSpellDtoList = new ArrayList<>();
+        summonerSpellDtoList = dtoMapper.toSummonerSpellDtoList(summonerSpellVOList);
+
+        //then
+        assertThat(summonerSpellDtoList.get(0).getName()).isEqualTo(name);
+        assertThat(summonerSpellDtoList.get(0).getDescription()).isEqualTo(description);
+        assertThat(summonerSpellDtoList.get(0).getSpellKey()).isEqualTo(spellKey);
+        assertThat(summonerSpellDtoList.get(0).getImage()).isEqualTo(image);
+    }
+}

--- a/inlol/src/test/java/dev/saariselka/inlol/controller/SummonerSpellControllerTest.java
+++ b/inlol/src/test/java/dev/saariselka/inlol/controller/SummonerSpellControllerTest.java
@@ -1,5 +1,7 @@
 package dev.saariselka.inlol.controller;
 
+import dev.saariselka.inlol.dto.DtoMapper;
+import dev.saariselka.inlol.dto.SummonerSpellDto;
 import dev.saariselka.inlol.entity.SummonerSpellEntity;
 import dev.saariselka.inlol.service.SummonerSpellService;
 import org.junit.jupiter.api.DisplayName;
@@ -22,6 +24,8 @@ public class SummonerSpellControllerTest {
     private SummonerSpellController summonerSpellController;
     @Autowired
     private SummonerSpellService summonerSpellService;
+    @Autowired
+    private DtoMapper dtoMapper;
 
 
     @Test
@@ -37,10 +41,10 @@ public class SummonerSpellControllerTest {
         summonerSpellController.insertSummonerSpell(name, description, spellKey, image);
 
         // then
-        SummonerSpellEntity summonerSpellEntitySaved = summonerSpellService.findByspellKey(spellKey).get(0);
+        SummonerSpellDto summonerSpellDtoSaved = dtoMapper.toSummonerSpellDtoList(summonerSpellService.findByspellKey(spellKey)).get(0);
 
-        assertThat(spellKey).isEqualTo(summonerSpellEntitySaved.getSpellKey());
-        assertThat(summonerSpellEntitySaved.getSpellKey()).isNotNull();
+        assertThat(spellKey).isEqualTo(summonerSpellDtoSaved.getSpellKey());
+        assertThat(summonerSpellDtoSaved.getSpellKey()).isNotNull();
     }
 
     @Test
@@ -52,18 +56,18 @@ public class SummonerSpellControllerTest {
         int spellKey = 0;
         String image = "testSummonerSpellImage";
 
-        List<SummonerSpellEntity> summonerSpellEntities = new ArrayList<>();
-        SummonerSpellEntity summonerSpellEntity = new SummonerSpellEntity(name,description,spellKey,image);
-        summonerSpellEntities.add(summonerSpellEntity);
+        List<SummonerSpellDto> summonerSpellDtos = new ArrayList<>();
+        SummonerSpellDto summonerSpellDto = new SummonerSpellDto(name,description,spellKey,image);
+        summonerSpellDtos.add(summonerSpellDto);
 
         // when
-        summonerSpellController.insertAllSummonerSpell(summonerSpellEntities);
+        summonerSpellController.insertAllSummonerSpell(summonerSpellDtos);
 
         // then
-        SummonerSpellEntity summonerSpellEntitySaved = summonerSpellService.findByspellKey(spellKey).get(0);
+        SummonerSpellDto summonerSpellDtoSaved = dtoMapper.toSummonerSpellDtoList(summonerSpellService.findByspellKey(spellKey)).get(0);
 
-        assertThat(spellKey).isEqualTo(summonerSpellEntitySaved.getSpellKey());
-        assertThat(summonerSpellEntitySaved.getSpellKey()).isNotNull();
+        assertThat(spellKey).isEqualTo(summonerSpellDtoSaved.getSpellKey());
+        assertThat(summonerSpellDtoSaved.getSpellKey()).isNotNull();
     }
 
     @Test
@@ -83,13 +87,13 @@ public class SummonerSpellControllerTest {
         summonerSpellService.insert(summonerSpellNameBooster, summonerSpellDescBooster, summonerSpellKeyBooster, summonerSpellImageBooster);
 
         // when
-        SummonerSpellEntity summonerSpellEntityBarrierFind = summonerSpellController.getSummonerSpellByKey(summonerSpellKeyBarrier).get(0);
-        SummonerSpellEntity summonerSpellEntityBoosterFind = summonerSpellController.getSummonerSpellByKey(summonerSpellKeyBooster).get(0);
+        SummonerSpellDto summonerSpellDtoBarrierFind = summonerSpellController.getSummonerSpellByKey(summonerSpellKeyBarrier).get(0);
+        SummonerSpellDto summonerSpellDtoBoosterFind = summonerSpellController.getSummonerSpellByKey(summonerSpellKeyBooster).get(0);
 
         // then
-        assertThat(summonerSpellEntityBarrierFind.getSpellKey()).isEqualTo(21);
-        assertThat(summonerSpellEntityBarrierFind.getImage()).isEqualTo("SummonerBarrier.png");
-        assertThat(summonerSpellEntityBoosterFind.getSpellKey()).isEqualTo(1);
-        assertThat(summonerSpellEntityBoosterFind.getImage()).isEqualTo("SummonerBoost.png");
+        assertThat(summonerSpellDtoBarrierFind.getSpellKey()).isEqualTo(21);
+        assertThat(summonerSpellDtoBarrierFind.getImage()).isEqualTo("SummonerBarrier.png");
+        assertThat(summonerSpellDtoBoosterFind.getSpellKey()).isEqualTo(1);
+        assertThat(summonerSpellDtoBoosterFind.getImage()).isEqualTo("SummonerBoost.png");
     }
 }

--- a/inlol/src/test/java/dev/saariselka/inlol/dto/SummonerSpellDtoTest.java
+++ b/inlol/src/test/java/dev/saariselka/inlol/dto/SummonerSpellDtoTest.java
@@ -1,0 +1,52 @@
+package dev.saariselka.inlol.dto;
+
+import dev.saariselka.inlol.entity.SummonerSpellEntity;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SummonerSpellDtoTest {
+
+
+    @Test
+    @DisplayName("SummonerSpellDto Lombok Get Function")
+    public void testLombokGetFunction() {
+
+        //given
+        String name = "testSummonerSpellName";
+        String description = "testSummonerSpellDesc";
+        int spellKey = 0;
+        String image = "testSummonerSpellImage";
+
+        //when
+        SummonerSpellDto summonerSpellDto = new SummonerSpellDto(name,description,spellKey,image);
+
+        //then
+        assertThat(summonerSpellDto.getName()).isEqualTo(name);
+        assertThat(summonerSpellDto.getDescription()).isEqualTo(description);
+        assertThat(summonerSpellDto.getSpellKey()).isEqualTo(spellKey);
+        assertThat(summonerSpellDto.getImage()).isEqualTo(image);
+    }
+
+    @Test
+    @DisplayName("SummonerSpellDto Lombok Set Function")
+    public void testLombokSetFunction() {
+        //given
+        String name = "testSummonerSpellName";
+        String description = "testSummonerSpellDesc";
+        int spellKey = 0;
+        String image = "testSummonerSpellImage";
+        SummonerSpellDto summonerSpellDto = new SummonerSpellDto(name,description,spellKey,image);
+
+        //when
+        String testSetFunctionImage = "tetSetFunctionSummonerSpellImage";
+        summonerSpellDto.setImage(testSetFunctionImage);
+
+        //then
+        assertThat(summonerSpellDto.getImage()).isEqualTo(testSetFunctionImage);
+    }
+}

--- a/inlol/src/test/java/dev/saariselka/inlol/facade/DBFacadeTest.java
+++ b/inlol/src/test/java/dev/saariselka/inlol/facade/DBFacadeTest.java
@@ -4,6 +4,7 @@ import dev.saariselka.inlol.controller.*;
 import dev.saariselka.inlol.dto.ChampionDto;
 import dev.saariselka.inlol.dto.LeagueEntryDto;
 import dev.saariselka.inlol.dto.SummonerDto;
+import dev.saariselka.inlol.dto.SummonerSpellDto;
 import dev.saariselka.inlol.entity.*;
 import dev.saariselka.inlol.repository.DdragonVersionRepository;
 import dev.saariselka.inlol.service.MatchParticipantService;
@@ -138,20 +139,20 @@ public class DBFacadeTest {
         int spellKey = 0;
         String image = "testSummonerSpellImage";
 
-        List<SummonerSpellEntity> summonerSpellEntities = new ArrayList<>();
+        List<SummonerSpellDto> summonerSpellDtoList = new ArrayList<>();
 
-        SummonerSpellEntity summonerSpellEntity = new SummonerSpellEntity(name, description, spellKey, image);
+        SummonerSpellDto summonerSpellDto = new SummonerSpellDto(name, description, spellKey, image);
 
-        summonerSpellEntities.add(summonerSpellEntity);
+        summonerSpellDtoList.add(summonerSpellDto);
 
         // when
-        dbFacade.setSummonerSpell(summonerSpellEntities);
+        dbFacade.setSummonerSpell(summonerSpellDtoList);
 
         // then
-        SummonerSpellEntity summonerSpellEntitySaved = summonerSpellController.getSummonerSpellByKey(spellKey).get(0);
+        SummonerSpellDto summonerSpellDtoSaved = summonerSpellController.getSummonerSpellByKey(spellKey).get(0);
 
-        assertThat(spellKey).isEqualTo(summonerSpellEntitySaved.getSpellKey());
-        assertThat(summonerSpellEntitySaved.getSpellKey()).isNotNull();
+        assertThat(spellKey).isEqualTo(summonerSpellDtoSaved.getSpellKey());
+        assertThat(summonerSpellDtoSaved.getSpellKey()).isNotNull();
     }
 
     @Test

--- a/inlol/src/test/java/dev/saariselka/inlol/service/SummonerSpellServiceTest.java
+++ b/inlol/src/test/java/dev/saariselka/inlol/service/SummonerSpellServiceTest.java
@@ -2,6 +2,8 @@ package dev.saariselka.inlol.service;
 
 import dev.saariselka.inlol.entity.SummonerSpellEntity;
 import dev.saariselka.inlol.repository.SummonerSpellRepository;
+import dev.saariselka.inlol.vo.SummonerSpellVO;
+import dev.saariselka.inlol.vo.VOMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,6 +24,8 @@ public class SummonerSpellServiceTest {
     private SummonerSpellService summonerSpellService;
     @Autowired
     private SummonerSpellRepository summonerSpellRepository;
+    @Autowired
+    private VOMapper voMapper;
 
     @Test
     @DisplayName("Insert Entity")
@@ -36,10 +40,10 @@ public class SummonerSpellServiceTest {
         summonerSpellService.insert(name, description, spellKey, image);
 
         // then
-        SummonerSpellEntity summonerSpellEntitySaved = summonerSpellRepository.findByspellKey(spellKey).get(0);
+        SummonerSpellVO summonerSpellVOSaved = voMapper.toSummonerSpellVOList(summonerSpellRepository.findByspellKey(spellKey)).get(0);
 
-        assertThat(spellKey).isEqualTo(summonerSpellEntitySaved.getSpellKey());
-        assertThat(summonerSpellEntitySaved.getSpellKey()).isNotNull();
+        assertThat(spellKey).isEqualTo(summonerSpellVOSaved.getSpellKey());
+        assertThat(summonerSpellVOSaved.getSpellKey()).isNotNull();
         assertThat(summonerSpellRepository.count()).isGreaterThan(0);
     }
 
@@ -52,18 +56,18 @@ public class SummonerSpellServiceTest {
         int spellKey = 0;
         String image = "testSummonerSpellImage";
 
-        List<SummonerSpellEntity> summonerSpellEntities = new ArrayList<>();
-        SummonerSpellEntity summonerSpellEntity = new SummonerSpellEntity(name,description,spellKey,image);
-        summonerSpellEntities.add(summonerSpellEntity);
+        List<SummonerSpellVO> summonerSpellVOList = new ArrayList<>();
+        SummonerSpellVO summonerSpellVO = new SummonerSpellVO(name,description,spellKey,image);
+        summonerSpellVOList.add(summonerSpellVO);
 
         // when
-        summonerSpellService.insertAll(summonerSpellEntities);
+        summonerSpellService.insertAll(summonerSpellVOList);
 
         // then
-        SummonerSpellEntity summonerSpellEntitySaved = summonerSpellRepository.findByspellKey(spellKey).get(0);
+        SummonerSpellVO summonerSpellVOSaved = voMapper.toSummonerSpellVOList(summonerSpellRepository.findByspellKey(spellKey)).get(0);
 
-        assertThat(spellKey).isEqualTo(summonerSpellEntitySaved.getSpellKey());
-        assertThat(summonerSpellEntitySaved.getSpellKey()).isNotNull();
+        assertThat(spellKey).isEqualTo(summonerSpellVOSaved.getSpellKey());
+        assertThat(summonerSpellVOSaved.getSpellKey()).isNotNull();
         assertThat(summonerSpellRepository.count()).isGreaterThan(0);
     }
 
@@ -87,14 +91,14 @@ public class SummonerSpellServiceTest {
         SummonerSpellEntity summonerSpellEntityBoosterSave = summonerSpellRepository.save(summonerSpellEntityBooster);
 
         // when
-        SummonerSpellEntity summonerSpellEntityBarrierFind = summonerSpellService.findByspellKey(summonerSpellEntityBarrierSave.getSpellKey()).get(0);
-        SummonerSpellEntity summonerSpellEntityBoosterFind = summonerSpellService.findByspellKey(summonerSpellEntityBoosterSave.getSpellKey()).get(0);
+        SummonerSpellVO summonerSpellVOBarrierFind = summonerSpellService.findByspellKey(summonerSpellEntityBarrierSave.getSpellKey()).get(0);
+        SummonerSpellVO summonerSpellVOBoosterFind = summonerSpellService.findByspellKey(summonerSpellEntityBoosterSave.getSpellKey()).get(0);
 
         // then
         assertThat(summonerSpellRepository.count()).isGreaterThan(0);
-        assertThat(summonerSpellEntityBarrierFind.getSpellKey()).isEqualTo(21);
-        assertThat(summonerSpellEntityBarrierFind.getImage()).isEqualTo("SummonerBarrier.png");
-        assertThat(summonerSpellEntityBoosterFind.getSpellKey()).isEqualTo(1);
-        assertThat(summonerSpellEntityBoosterFind.getImage()).isEqualTo("SummonerBoost.png");
+        assertThat(summonerSpellVOBarrierFind.getSpellKey()).isEqualTo(21);
+        assertThat(summonerSpellVOBarrierFind.getImage()).isEqualTo("SummonerBarrier.png");
+        assertThat(summonerSpellVOBoosterFind.getSpellKey()).isEqualTo(1);
+        assertThat(summonerSpellVOBoosterFind.getImage()).isEqualTo("SummonerBoost.png");
     }
 }

--- a/inlol/src/test/java/dev/saariselka/inlol/vo/SummonerSpellVOTest.java
+++ b/inlol/src/test/java/dev/saariselka/inlol/vo/SummonerSpellVOTest.java
@@ -1,0 +1,47 @@
+package dev.saariselka.inlol.vo;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SummonerSpellVOTest {
+
+    @Test
+    @DisplayName("SummonerSpellVO Lombok Get Function")
+    public void testLombokGetFunction() {
+
+        //given
+        String name = "testSummonerSpellName";
+        String description = "testSummonerSpellDesc";
+        int spellKey = 0;
+        String image = "testSummonerSpellImage";
+
+        //when
+        SummonerSpellVO summonerSpellVO = new SummonerSpellVO(name,description,spellKey,image);
+
+        //then
+        assertThat(summonerSpellVO.getName()).isEqualTo(name);
+        assertThat(summonerSpellVO.getDescription()).isEqualTo(description);
+        assertThat(summonerSpellVO.getSpellKey()).isEqualTo(spellKey);
+        assertThat(summonerSpellVO.getImage()).isEqualTo(image);
+    }
+
+    @Test
+    @DisplayName("SummonerSpellVO Lombok Set Function")
+    public void testLombokSetFunction() {
+        //given
+        String name = "testSummonerSpellName";
+        String description = "testSummonerSpellDesc";
+        int spellKey = 0;
+        String image = "testSummonerSpellImage";
+        SummonerSpellVO summonerSpellVO = new SummonerSpellVO(name,description,spellKey,image);
+
+        //when
+        String testSetFunctionImage = "tetSetFunctionSummonerSpellImage";
+        summonerSpellVO.setImage(testSetFunctionImage);
+
+        //then
+        assertThat(summonerSpellVO.getImage()).isEqualTo(testSetFunctionImage);
+    }
+}

--- a/inlol/src/test/java/dev/saariselka/inlol/vo/VOMapperTest.java
+++ b/inlol/src/test/java/dev/saariselka/inlol/vo/VOMapperTest.java
@@ -1,0 +1,66 @@
+package dev.saariselka.inlol.vo;
+
+import dev.saariselka.inlol.dto.SummonerSpellDto;
+import dev.saariselka.inlol.entity.SummonerSpellEntity;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class VOMapperTest {
+
+    @Autowired
+    VOMapper voMapper;
+
+    @Test
+    @DisplayName("Convert SummonerSpellVOList To SummonerSpellEntityList")
+    public void toSummonerSpellEntityList() {
+
+        //given
+        String name = "testSummonerSpellName";
+        String description = "testSummonerSpellDesc";
+        int spellKey = 0;
+        String image = "testSummonerSpellImage";
+        SummonerSpellVO summonerSpellVO = new SummonerSpellVO(name,description,spellKey,image);
+        List<SummonerSpellVO> summonerSpellVOList = new ArrayList<>();
+        summonerSpellVOList.add(summonerSpellVO);
+
+        //when
+        List<SummonerSpellEntity> summonerSpellEntities = new ArrayList<>();
+        summonerSpellEntities = voMapper.toSummonerSpellEntityList(summonerSpellVOList);
+
+        //then
+        assertThat(summonerSpellEntities.get(0).getName()).isEqualTo(name);
+        assertThat(summonerSpellEntities.get(0).getDescription()).isEqualTo(description);
+        assertThat(summonerSpellEntities.get(0).getSpellKey()).isEqualTo(spellKey);
+        assertThat(summonerSpellEntities.get(0).getImage()).isEqualTo(image);
+    }
+
+    @Test
+    @DisplayName("Convert SummonerSpellDtoList To SummonerSpellVOList")
+    public void toSummonerSpellVOList() {
+
+        //given
+        String name = "testSummonerSpellName";
+        String description = "testSummonerSpellDesc";
+        int spellKey = 0;
+        String image = "testSummonerSpellImage";
+        SummonerSpellEntity summonerSpellEntity = new SummonerSpellEntity(name,description,spellKey,image);
+        List<SummonerSpellEntity> summonerSpellEntityList = new ArrayList<>();
+        summonerSpellEntityList.add(summonerSpellEntity);
+
+        //when
+        List<SummonerSpellVO> summonerSpellVOList = new ArrayList<>();
+        summonerSpellVOList = voMapper.toSummonerSpellVOList(summonerSpellEntityList);
+
+        //then
+        assertThat(summonerSpellVOList.get(0).getName()).isEqualTo(name);
+        assertThat(summonerSpellVOList.get(0).getDescription()).isEqualTo(description);
+        assertThat(summonerSpellVOList.get(0).getSpellKey()).isEqualTo(spellKey);
+        assertThat(summonerSpellVOList.get(0).getImage()).isEqualTo(image);
+    }
+}


### PR DESCRIPTION
- new
 . class : SummonerSpellDto, SummonerSpellVO
 . method : DtoMapper - toSummonerSpellDtoList, toSummonerSpellVOList
            VOMapper - toSummonerVOList, toSummonerEntityList

- change
 . SummonerSpell Dto, VO 도입에 따른 SummonerSpell Entity 활용 로직 변경