### PR TITLE
MacthBan Dto, VO 적용 관련 변경

### DIFF
--- a/inlol/src/main/java/dev/saariselka/inlol/controller/MatchBanController.java
+++ b/inlol/src/main/java/dev/saariselka/inlol/controller/MatchBanController.java
@@ -1,5 +1,7 @@
 package dev.saariselka.inlol.controller;
 
+import dev.saariselka.inlol.dto.DtoMapper;
+import dev.saariselka.inlol.dto.MatchBanDto;
 import dev.saariselka.inlol.entity.MatchBanEntity;
 import dev.saariselka.inlol.entity.MatchBanId;
 import dev.saariselka.inlol.service.MatchBanService;
@@ -24,17 +26,19 @@ public class MatchBanController {
 
     @Autowired
     MatchBanService matchBanService;
+    @Autowired
+    DtoMapper dtoMapper;
 
-    public List<MatchBanEntity> getBansByMatchId(String matchId) {
-        return matchBanService.findByMatchId(matchId);
+    public List<MatchBanDto> getBansByMatchId(String matchId) {
+        return dtoMapper.toMatchBanDtoList(matchBanService.findByMatchId(matchId));
     }
 
-    public List<MatchBanEntity> getBansByMatchBanId(String matchId, int pickTurn, int teamId) {
-        return matchBanService.findByMatchBanId(new MatchBanId(matchId, pickTurn, teamId));
+    public List<MatchBanDto> getBansByMatchBanId(String matchId, int pickTurn, int teamId) {
+        return dtoMapper.toMatchBanDtoList(matchBanService.findByMatchBanId(new MatchBanId(matchId, pickTurn, teamId)));
     }
 
-    public List<MatchBanEntity> getBansByMatchBanIdAndTeamId(String matchId, int teamId) {
-        return matchBanService.findByMatchIdAndTeamId(matchId, teamId);
+    public List<MatchBanDto> getBansByMatchBanIdAndTeamId(String matchId, int teamId) {
+        return dtoMapper.toMatchBanDtoList(matchBanService.findByMatchIdAndTeamId(matchId, teamId));
     }
 
     public void insertBanInfo(String matchId, int pickTurn, int teamId, int championId, Timestamp rrt) {

--- a/inlol/src/main/java/dev/saariselka/inlol/dto/DtoMapper.java
+++ b/inlol/src/main/java/dev/saariselka/inlol/dto/DtoMapper.java
@@ -1,6 +1,7 @@
 package dev.saariselka.inlol.dto;
 
 import dev.saariselka.inlol.vo.ChampionVO;
+import dev.saariselka.inlol.vo.MatchBanVO;
 import dev.saariselka.inlol.vo.SummonerSpellVO;
 import lombok.NoArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -45,5 +46,27 @@ public class DtoMapper {
         }
 
         return summonerSpellDtoList;
+    }
+
+    public List<MatchBanDto> toMatchBanDtoList(List<MatchBanVO> matchBanVOList) {
+        List<MatchBanDto> matchBanDtoList = new ArrayList<>();
+
+        for(MatchBanVO matchBanVO : matchBanVOList) {
+            MatchBanDto matchBanDto = new MatchBanDto(matchBanVO.getMatchId(),matchBanVO.getPickTurn(),matchBanVO.getTeamId(),matchBanVO.getChampionId());
+            matchBanDtoList.add(matchBanDto);
+        }
+
+        return matchBanDtoList;
+    }
+
+    public List<MatchBanVO> toMatchBanVOList(List<MatchBanDto> matchBanDtoList) {
+        List<MatchBanVO> matchBanVOList = new ArrayList<>();
+
+        for(MatchBanDto matchBanDto : matchBanDtoList) {
+            MatchBanVO matchBanVO = new MatchBanVO(matchBanDto.getMatchId(),matchBanDto.getPickTurn(),matchBanDto.getTeamId(),matchBanDto.getChampionId());
+            matchBanVOList.add(matchBanVO);
+        }
+
+        return matchBanVOList;
     }
 }

--- a/inlol/src/main/java/dev/saariselka/inlol/dto/MatchBanDto.java
+++ b/inlol/src/main/java/dev/saariselka/inlol/dto/MatchBanDto.java
@@ -1,0 +1,15 @@
+package dev.saariselka.inlol.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class MatchBanDto {
+    private String matchId;
+    private int pickTurn;
+    private int teamId;
+    private int championId;
+}

--- a/inlol/src/main/java/dev/saariselka/inlol/dto/TeamDto.java
+++ b/inlol/src/main/java/dev/saariselka/inlol/dto/TeamDto.java
@@ -11,17 +11,17 @@ import java.util.List;
 @Setter
 @NoArgsConstructor
 public class TeamDto {
-    private List<BanDto> bans;
+    private List<MatchBanDto> bans;
     private ObjectivesDto objectives;
     private String teamId;
     private String win;
     private int teamKills;
     private List<ParticipantDto> participants;
 
-    public TeamDto (TeamEntity teamEntity, List<BanDto> banDtoList, ObjectivesDto objectivesDto) {
+    public TeamDto (TeamEntity teamEntity, List<MatchBanDto> matchBanDtoList, ObjectivesDto objectivesDto) {
         this.teamId = String.valueOf(teamEntity.getTeamId().getTeamId());
         this.win = String.valueOf(teamEntity.isWin());
-        this.bans = banDtoList;
+        this.bans = matchBanDtoList;
         this.objectives = objectivesDto;
     }
 }

--- a/inlol/src/main/java/dev/saariselka/inlol/facade/DBFacade.java
+++ b/inlol/src/main/java/dev/saariselka/inlol/facade/DBFacade.java
@@ -177,22 +177,15 @@ public class DBFacade {
             List<TeamDto> teamDtoList = new ArrayList<>();
 
             for(TeamEntity teamEntity : teamEntityList) {
-                List<MatchBanEntity> matchBanEntityList = matchBanController.getBansByMatchBanIdAndTeamId(matchId, teamEntity.getTeamId().getTeamId());
+                List<MatchBanDto> matchBanDtoList = matchBanController.getBansByMatchBanIdAndTeamId(matchId, teamEntity.getTeamId().getTeamId());
 
                 MatchObjectivesEntity matchObjectivesEntity = matchObjectivesController
                         .getMatchObjectivesByMatchIdAndTeamId(matchId, teamEntity.getTeamId().getTeamId())
                         .get(0);
 
-                List<BanDto> banDtoList = new ArrayList<>();
-
-                for(MatchBanEntity matchBanEntity : matchBanEntityList) {
-                    BanDto banDto = new BanDto(matchBanEntity);
-                    banDtoList.add(banDto);
-                }
-
                 ObjectivesDto objectivesDto = new ObjectivesDto(matchObjectivesEntity);
 
-                TeamDto teamDto = new TeamDto(teamEntity,banDtoList,objectivesDto);
+                TeamDto teamDto = new TeamDto(teamEntity,matchBanDtoList,objectivesDto);
                 teamDtoList.add(teamDto);
             }
 

--- a/inlol/src/main/java/dev/saariselka/inlol/facade_obsolete/Facade_Get.java
+++ b/inlol/src/main/java/dev/saariselka/inlol/facade_obsolete/Facade_Get.java
@@ -102,22 +102,15 @@ public class Facade_Get {
             List<TeamDto> teamDtoList = new ArrayList<>();
 
             for(TeamEntity teamEntity : teamEntityList) {
-                List<MatchBanEntity> matchBanEntityList = matchBanController.getBansByMatchBanIdAndTeamId(matchId, teamEntity.getTeamId().getTeamId());
+                List<MatchBanDto> matchBanDtoList = matchBanController.getBansByMatchBanIdAndTeamId(matchId, teamEntity.getTeamId().getTeamId());
 
                 MatchObjectivesEntity matchObjectivesEntity = matchObjectivesController
                         .getMatchObjectivesByMatchIdAndTeamId(matchId, teamEntity.getTeamId().getTeamId())
                         .get(0);
 
-                List<BanDto> banDtoList = new ArrayList<>();
-
-                for(MatchBanEntity matchBanEntity : matchBanEntityList) {
-                    BanDto banDto = new BanDto(matchBanEntity);
-                    banDtoList.add(banDto);
-                }
-
                 ObjectivesDto objectivesDto = new ObjectivesDto(matchObjectivesEntity);
 
-                TeamDto teamDto = new TeamDto(teamEntity,banDtoList,objectivesDto);
+                TeamDto teamDto = new TeamDto(teamEntity,matchBanDtoList,objectivesDto);
                 teamDtoList.add(teamDto);
             }
 

--- a/inlol/src/main/java/dev/saariselka/inlol/service/MatchBanService.java
+++ b/inlol/src/main/java/dev/saariselka/inlol/service/MatchBanService.java
@@ -3,6 +3,8 @@ package dev.saariselka.inlol.service;
 import dev.saariselka.inlol.entity.MatchBanEntity;
 import dev.saariselka.inlol.entity.MatchBanId;
 import dev.saariselka.inlol.repository.MatchBanRepository;
+import dev.saariselka.inlol.vo.MatchBanVO;
+import dev.saariselka.inlol.vo.VOMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -16,17 +18,19 @@ import java.util.List;
 public class MatchBanService {
     @Autowired
     private final MatchBanRepository matchBanRepository;
+    @Autowired
+    VOMapper voMapper;
 
-    public List<MatchBanEntity> findByMatchId(String matchId) {
-        return matchBanRepository.findByMatchBanId_MatchId(matchId);
+    public List<MatchBanVO> findByMatchId(String matchId) {
+        return voMapper.toMatchBanVOList(matchBanRepository.findByMatchBanId_MatchId(matchId));
     }
 
-    public List<MatchBanEntity> findByMatchIdAndTeamId(String matchId, int teamId) {
-        return matchBanRepository.findByMatchBanId_MatchIdAndMatchBanId_TeamId(matchId, teamId);
+    public List<MatchBanVO> findByMatchIdAndTeamId(String matchId, int teamId) {
+        return voMapper.toMatchBanVOList(matchBanRepository.findByMatchBanId_MatchIdAndMatchBanId_TeamId(matchId, teamId));
     }
 
-    public List<MatchBanEntity> findByMatchBanId(MatchBanId matchBanId) {
-        return matchBanRepository.findByMatchBanId(matchBanId);
+    public List<MatchBanVO> findByMatchBanId(MatchBanId matchBanId) {
+        return voMapper.toMatchBanVOList(matchBanRepository.findByMatchBanId(matchBanId));
     }
 
     public void insert(String matchId, int pickTurn, int teamId, int championId, Timestamp rrt) {

--- a/inlol/src/main/java/dev/saariselka/inlol/vo/MatchBanVO.java
+++ b/inlol/src/main/java/dev/saariselka/inlol/vo/MatchBanVO.java
@@ -1,0 +1,18 @@
+package dev.saariselka.inlol.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MatchBanVO {
+
+    private String matchId;
+    private int pickTurn;
+    private int teamId;
+    private int championId;
+}

--- a/inlol/src/main/java/dev/saariselka/inlol/vo/VOMapper.java
+++ b/inlol/src/main/java/dev/saariselka/inlol/vo/VOMapper.java
@@ -1,10 +1,9 @@
 package dev.saariselka.inlol.vo;
 
+import java.sql.Timestamp;
 import java.util.List;
 
-import dev.saariselka.inlol.entity.ChampionEntity;
-import dev.saariselka.inlol.entity.QueueTypeEntity;
-import dev.saariselka.inlol.entity.SummonerSpellEntity;
+import dev.saariselka.inlol.entity.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -65,5 +64,24 @@ public class VOMapper {
             summonerSpellEntities.add(summonerSpellEntity);
         }
         return  summonerSpellEntities;
+    }
+
+    public List<MatchBanVO> toMatchBanVOList(List<MatchBanEntity> matchBanEntityList) {
+        List<MatchBanVO> matchBanVOList = new ArrayList<>();
+        for(MatchBanEntity matchBanEntity : matchBanEntityList) {
+            MatchBanVO matchBanVO = new MatchBanVO(matchBanEntity.getMatchBanId().getMatchId(),matchBanEntity.getMatchBanId().getPickTurn(),matchBanEntity.getMatchBanId().getTeamId(),matchBanEntity.getChampionId());
+            matchBanVOList.add(matchBanVO);
+        }
+        return  matchBanVOList;
+    }
+
+    public List<MatchBanEntity> toMatchBanEntityList(List<MatchBanVO> matchBanVOList) {
+        List<MatchBanEntity> matchBanEntityList = new ArrayList<>();
+        Timestamp rrt = new Timestamp(System.currentTimeMillis());
+        for(MatchBanVO matchBanVO : matchBanVOList) {
+            MatchBanEntity matchBanEntity = new MatchBanEntity(new MatchBanId(matchBanVO.getMatchId(),matchBanVO.getPickTurn(),matchBanVO.getTeamId()),matchBanVO.getChampionId(),rrt);
+            matchBanEntityList.add(matchBanEntity);
+        }
+        return  matchBanEntityList;
     }
 }

--- a/inlol/src/test/java/dev/saariselka/inlol/controller/DtoMapperTest.java
+++ b/inlol/src/test/java/dev/saariselka/inlol/controller/DtoMapperTest.java
@@ -1,14 +1,19 @@
 package dev.saariselka.inlol.controller;
 
 import dev.saariselka.inlol.dto.DtoMapper;
+import dev.saariselka.inlol.dto.MatchBanDto;
 import dev.saariselka.inlol.dto.SummonerDto;
 import dev.saariselka.inlol.dto.SummonerSpellDto;
+import dev.saariselka.inlol.entity.MatchBanEntity;
+import dev.saariselka.inlol.entity.MatchBanId;
+import dev.saariselka.inlol.vo.MatchBanVO;
 import dev.saariselka.inlol.vo.SummonerSpellVO;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -66,5 +71,53 @@ public class DtoMapperTest {
         assertThat(summonerSpellDtoList.get(0).getDescription()).isEqualTo(description);
         assertThat(summonerSpellDtoList.get(0).getSpellKey()).isEqualTo(spellKey);
         assertThat(summonerSpellDtoList.get(0).getImage()).isEqualTo(image);
+    }
+
+
+    @Test
+    @DisplayName("Convert MatchBanDtoList To MatchBanVOList")
+    public void toMatchBanVOList() {
+
+        //given
+        String matchId = "KR_5804413147";
+        int pickTurn = 1;
+        int teamId = 100;
+        int championId = 99;
+        MatchBanDto matchBanDto = new MatchBanDto(matchId,pickTurn,teamId,championId);
+        List<MatchBanDto> matchBanDtoList = new ArrayList<>();
+        matchBanDtoList.add(matchBanDto);
+
+        //when
+        List<MatchBanVO> matchBanVOList = new ArrayList<>();
+        matchBanVOList = dtoMapper.toMatchBanVOList(matchBanDtoList);
+
+        //then
+        assertThat(matchBanVOList.get(0).getMatchId()).isEqualTo(matchId);
+        assertThat(matchBanVOList.get(0).getPickTurn()).isEqualTo(pickTurn);
+        assertThat(matchBanVOList.get(0).getTeamId()).isEqualTo(teamId);
+        assertThat(matchBanVOList.get(0).getChampionId()).isEqualTo(championId);
+    }
+
+    @Test
+    @DisplayName("Convert MatchBanVOList To MatchBanDtoList")
+    public void toMatchBanDtoList() {
+        //given
+        String matchId = "KR_5804413147";
+        int pickTurn = 1;
+        int teamId = 100;
+        int championId = 99;
+        MatchBanVO matchBanVO = new MatchBanVO(matchId,pickTurn,teamId,championId);
+        List<MatchBanVO> matchBanVOList = new ArrayList<>();
+        matchBanVOList.add(matchBanVO);
+
+        //when
+        List<MatchBanDto> matchBanDtoList = new ArrayList<>();
+        matchBanDtoList = dtoMapper.toMatchBanDtoList(matchBanVOList);
+
+        //then
+        assertThat(matchBanDtoList.get(0).getMatchId()).isEqualTo(matchId);
+        assertThat(matchBanDtoList.get(0).getPickTurn()).isEqualTo(pickTurn);
+        assertThat(matchBanDtoList.get(0).getTeamId()).isEqualTo(teamId);
+        assertThat(matchBanDtoList.get(0).getChampionId()).isEqualTo(championId);
     }
 }

--- a/inlol/src/test/java/dev/saariselka/inlol/controller/MatchBanControllerTest.java
+++ b/inlol/src/test/java/dev/saariselka/inlol/controller/MatchBanControllerTest.java
@@ -1,5 +1,7 @@
 package dev.saariselka.inlol.controller;
 
+import dev.saariselka.inlol.dto.DtoMapper;
+import dev.saariselka.inlol.dto.MatchBanDto;
 import dev.saariselka.inlol.entity.MatchBanEntity;
 import dev.saariselka.inlol.entity.MatchBanId;
 import dev.saariselka.inlol.repository.MatchBanRepository;
@@ -22,7 +24,8 @@ public class MatchBanControllerTest {
     private MatchBanController matchBanController;
     @Autowired
     private MatchBanService matchBanService;
-
+    @Autowired
+    DtoMapper dtoMapper;
 
     @Test
     @DisplayName("Insert Entity")
@@ -38,14 +41,16 @@ public class MatchBanControllerTest {
         matchBanController.insertBanInfo(matchId,pickTurn,teamId,championId,rrt);
 
         // then
-        MatchBanEntity matchBanEntitySaved = matchBanService.findByMatchBanId(new MatchBanId(matchId,pickTurn,teamId)).get(0);
+        MatchBanDto matchBanDtoSaved = dtoMapper.toMatchBanDtoList(matchBanService.findByMatchBanId(new MatchBanId(matchId,pickTurn,teamId))).get(0);
 
-        assertThat(new MatchBanId(matchId, pickTurn, teamId)).isEqualTo(matchBanEntitySaved.getMatchBanId());
-        assertThat(matchBanEntitySaved.getMatchBanId()).isNotNull();
+        assertThat(matchBanDtoSaved.getMatchId()).isEqualTo(matchId);
+        assertThat(matchBanDtoSaved.getPickTurn()).isEqualTo(pickTurn);
+        assertThat(matchBanDtoSaved.getTeamId()).isEqualTo(teamId);
+        assertThat(matchBanDtoSaved.getChampionId()).isEqualTo(championId);
     }
 
     @Test
-    @DisplayName("Find Entity By MatchBanId")
+    @DisplayName("Find Dto By MatchBanId")
     public void getBansByMatchBanId() {
         // given
         String matchId = "KR_5804413147";
@@ -62,18 +67,18 @@ public class MatchBanControllerTest {
         matchBanService.insert(matchId,pickTurnSecond,teamIdSecond,championIdSecond,rrt);
 
         // when
-        MatchBanEntity matchBanEntityFindFirst = matchBanController.getBansByMatchBanId(matchId,pickTurnFirst,teamIdFirst).get(0);
-        MatchBanEntity matchBanEntityFindSecond = matchBanController.getBansByMatchBanId(matchId,pickTurnSecond,teamIdSecond).get(0);
+        MatchBanDto matchBanDtoFindFirst = matchBanController.getBansByMatchBanId(matchId,pickTurnFirst,teamIdFirst).get(0);
+        MatchBanDto matchBanDtoFindSecond = matchBanController.getBansByMatchBanId(matchId,pickTurnSecond,teamIdSecond).get(0);
 
         // then
-        assertThat(matchBanEntityFindFirst.getMatchBanId().getPickTurn()).isEqualTo(1);
-        assertThat(matchBanEntityFindFirst.getChampionId()).isEqualTo(99);
-        assertThat(matchBanEntityFindSecond.getMatchBanId().getPickTurn()).isEqualTo(2);
-        assertThat(matchBanEntityFindSecond.getChampionId()).isEqualTo(100);
+        assertThat(matchBanDtoFindFirst.getPickTurn()).isEqualTo(1);
+        assertThat(matchBanDtoFindFirst.getChampionId()).isEqualTo(99);
+        assertThat(matchBanDtoFindSecond.getPickTurn()).isEqualTo(2);
+        assertThat(matchBanDtoFindSecond.getChampionId()).isEqualTo(100);
     }
 
     @Test
-    @DisplayName("Find Entity By MatchBanId.MatchId")
+    @DisplayName("Find Dto By MatchBanId.MatchId")
     public void getBansByMatchId() {
         // given
         String matchIdFirst = "KR_5804413147";
@@ -91,18 +96,18 @@ public class MatchBanControllerTest {
         matchBanService.insert(matchIdSecond,pickTurnSecond,teamIdSecond,championIdSecond,rrt);
 
         // when
-        MatchBanEntity matchBanEntityFindFirst = matchBanController.getBansByMatchId(matchIdFirst).get(0);
-        MatchBanEntity matchBanEntityFindSecond = matchBanController.getBansByMatchId(matchIdSecond).get(0);
+        MatchBanDto matchBanDtoFindFirst = matchBanController.getBansByMatchId(matchIdFirst).get(0);
+        MatchBanDto matchBanDtoFindSecond = matchBanController.getBansByMatchId(matchIdSecond).get(0);
 
         // then
-        assertThat(matchBanEntityFindFirst.getMatchBanId().getMatchId()).isEqualTo("KR_5804413147");
-        assertThat(matchBanEntityFindFirst.getChampionId()).isEqualTo(99);
-        assertThat(matchBanEntityFindSecond.getMatchBanId().getMatchId()).isEqualTo("KR_5804413148");
-        assertThat(matchBanEntityFindSecond.getChampionId()).isEqualTo(100);
+        assertThat(matchBanDtoFindFirst.getMatchId()).isEqualTo("KR_5804413147");
+        assertThat(matchBanDtoFindFirst.getChampionId()).isEqualTo(99);
+        assertThat(matchBanDtoFindSecond.getMatchId()).isEqualTo("KR_5804413148");
+        assertThat(matchBanDtoFindSecond.getChampionId()).isEqualTo(100);
     }
 
     @Test
-    @DisplayName("Find Entity By MatchBanId.MatchId, MatchBanId.TeamId")
+    @DisplayName("Find Dto By MatchBanId.MatchId, MatchBanId.TeamId")
     public void getBansByMatchBanIdAndTeamId() {
         // given
         String matchId = "KR_5804413147";
@@ -119,14 +124,14 @@ public class MatchBanControllerTest {
         matchBanService.insert(matchId,pickTurnSecond,teamIdSecond,championIdSecond,rrt);
 
         // when
-        MatchBanEntity matchBanEntityFindFirst = matchBanController.getBansByMatchBanIdAndTeamId(matchId,teamIdFirst).get(0);
-        MatchBanEntity matchBanEntityFindSecond = matchBanController.getBansByMatchBanIdAndTeamId(matchId,teamIdSecond).get(0);
+        MatchBanDto matchBanDtoFindFirst = matchBanController.getBansByMatchBanIdAndTeamId(matchId,teamIdFirst).get(0);
+        MatchBanDto matchBanDtoFindSecond = matchBanController.getBansByMatchBanIdAndTeamId(matchId,teamIdSecond).get(0);
 
         // then
-        assertThat(matchBanEntityFindFirst.getMatchBanId().getMatchId()).isEqualTo("KR_5804413147");
-        assertThat(matchBanEntityFindFirst.getMatchBanId().getTeamId()).isEqualTo(100);
-        assertThat(matchBanEntityFindSecond.getMatchBanId().getMatchId()).isEqualTo("KR_5804413147");
-        assertThat(matchBanEntityFindSecond.getMatchBanId().getTeamId()).isEqualTo(200);
+        assertThat(matchBanDtoFindFirst.getMatchId()).isEqualTo("KR_5804413147");
+        assertThat(matchBanDtoFindFirst.getTeamId()).isEqualTo(100);
+        assertThat(matchBanDtoFindSecond.getMatchId()).isEqualTo("KR_5804413147");
+        assertThat(matchBanDtoFindSecond.getTeamId()).isEqualTo(200);
     }
 }
 

--- a/inlol/src/test/java/dev/saariselka/inlol/dto/MatchBanDtoTest.java
+++ b/inlol/src/test/java/dev/saariselka/inlol/dto/MatchBanDtoTest.java
@@ -1,0 +1,47 @@
+package dev.saariselka.inlol.dto;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MatchBanDtoTest {
+
+    @Test
+    @DisplayName("MatchBanDto Lombok Get Function")
+    public void testLombokGetFunction() {
+
+        //given
+        String matchId = "KR_5804413147";
+        int pickTurn = 1;
+        int teamId = 100;
+        int championId = 99;
+
+        //when
+        MatchBanDto matchBanDto = new MatchBanDto(matchId, pickTurn, teamId, championId);
+
+        //then
+        assertThat(matchBanDto.getMatchId()).isEqualTo(matchId);
+        assertThat(matchBanDto.getPickTurn()).isEqualTo(pickTurn);
+        assertThat(matchBanDto.getTeamId()).isEqualTo(teamId);
+        assertThat(matchBanDto.getChampionId()).isEqualTo(championId);
+    }
+
+    @Test
+    @DisplayName("MatchBanDto Lombok Set Function")
+    public void testLombokSetFunction() {
+        //given
+        String matchId = "KR_5804413147";
+        int pickTurn = 1;
+        int teamId = 100;
+        int championId = 99;
+        MatchBanDto matchBanDto = new MatchBanDto(matchId, pickTurn, teamId, championId);
+
+        //when
+        int testChampionId = 100;
+        matchBanDto.setChampionId(testChampionId);
+
+        //then
+        assertThat(matchBanDto.getChampionId()).isEqualTo(testChampionId);
+    }
+}

--- a/inlol/src/test/java/dev/saariselka/inlol/dto/TeamDtoTest.java
+++ b/inlol/src/test/java/dev/saariselka/inlol/dto/TeamDtoTest.java
@@ -13,13 +13,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TeamDtoTest {
     TeamEntity entity;
-    List<BanDto> banDtoList;
+    List<MatchBanDto> matchBanDtoList;
     ObjectivesDto objectivesDto;
 
     @BeforeEach
     void init() {
         entity = createTestTeamEntity();
-        banDtoList = createTestBanDtoList();
+        matchBanDtoList = createTestMatchBanDtoList();
         objectivesDto = createTestObjectivesDto();
     }
 
@@ -32,19 +32,19 @@ public class TeamDtoTest {
         //ObjectivesDto objectivesDto = createTestObjectivesDto();
 
         //when
-        TeamDto dto = new TeamDto(entity, banDtoList, objectivesDto);
+        TeamDto dto = new TeamDto(entity, matchBanDtoList, objectivesDto);
 
         //then
-        assertThat(dto.getBans().get(0).getChampionId()).isEqualTo("221");
-        assertThat(dto.getBans().get(0).getPickTurn()).isEqualTo("1");
-        assertThat(dto.getBans().get(1).getChampionId()).isEqualTo("-1");
-        assertThat(dto.getBans().get(1).getPickTurn()).isEqualTo("2");
-        assertThat(dto.getBans().get(2).getChampionId()).isEqualTo("200");
-        assertThat(dto.getBans().get(2).getPickTurn()).isEqualTo("3");
-        assertThat(dto.getBans().get(3).getChampionId()).isEqualTo("55");
-        assertThat(dto.getBans().get(3).getPickTurn()).isEqualTo("4");
-        assertThat(dto.getBans().get(4).getChampionId()).isEqualTo("10");
-        assertThat(dto.getBans().get(4).getPickTurn()).isEqualTo("5");
+        assertThat(dto.getBans().get(0).getChampionId()).isEqualTo(221);
+        assertThat(dto.getBans().get(0).getPickTurn()).isEqualTo(1);
+        assertThat(dto.getBans().get(1).getChampionId()).isEqualTo(-1);
+        assertThat(dto.getBans().get(1).getPickTurn()).isEqualTo(2);
+        assertThat(dto.getBans().get(2).getChampionId()).isEqualTo(200);
+        assertThat(dto.getBans().get(2).getPickTurn()).isEqualTo(3);
+        assertThat(dto.getBans().get(3).getChampionId()).isEqualTo(55);
+        assertThat(dto.getBans().get(3).getPickTurn()).isEqualTo(4);
+        assertThat(dto.getBans().get(4).getChampionId()).isEqualTo(10);
+        assertThat(dto.getBans().get(4).getPickTurn()).isEqualTo(5);
 
         assertThat(dto.getObjectives().getBaron().isFirst()).isTrue();
         assertThat(dto.getObjectives().getBaron().getKills()).isEqualTo(2);
@@ -67,19 +67,19 @@ public class TeamDtoTest {
     @DisplayName("Setter")
     void setter() {
         // given
-        TeamDto dto = new TeamDto(entity, banDtoList, objectivesDto);
+        TeamDto dto = new TeamDto(entity, matchBanDtoList, objectivesDto);
 
         // when
-        dto.getBans().get(0).setChampionId("220");
-        dto.getBans().get(0).setPickTurn("2");
-        dto.getBans().get(1).setChampionId("2");
-        dto.getBans().get(1).setPickTurn("3");
-        dto.getBans().get(2).setChampionId("199");
-        dto.getBans().get(2).setPickTurn("4");
-        dto.getBans().get(3).setChampionId("50");
-        dto.getBans().get(3).setPickTurn("5");
-        dto.getBans().get(4).setChampionId("8");
-        dto.getBans().get(4).setPickTurn("1");
+        dto.getBans().get(0).setChampionId(220);
+        dto.getBans().get(0).setPickTurn(2);
+        dto.getBans().get(1).setChampionId(2);
+        dto.getBans().get(1).setPickTurn(3);
+        dto.getBans().get(2).setChampionId(199);
+        dto.getBans().get(2).setPickTurn(4);
+        dto.getBans().get(3).setChampionId(50);
+        dto.getBans().get(3).setPickTurn(5);
+        dto.getBans().get(4).setChampionId(8);
+        dto.getBans().get(4).setPickTurn(1);
 
         dto.getObjectives().getBaron().setFirst(false);
         dto.getObjectives().getBaron().setKills(3);
@@ -98,16 +98,16 @@ public class TeamDtoTest {
         dto.setWin("false");
 
         // then
-        assertThat(dto.getBans().get(0).getChampionId()).isEqualTo("220");
-        assertThat(dto.getBans().get(0).getPickTurn()).isEqualTo("2");
-        assertThat(dto.getBans().get(1).getChampionId()).isEqualTo("2");
-        assertThat(dto.getBans().get(1).getPickTurn()).isEqualTo("3");
-        assertThat(dto.getBans().get(2).getChampionId()).isEqualTo("199");
-        assertThat(dto.getBans().get(2).getPickTurn()).isEqualTo("4");
-        assertThat(dto.getBans().get(3).getChampionId()).isEqualTo("50");
-        assertThat(dto.getBans().get(3).getPickTurn()).isEqualTo("5");
-        assertThat(dto.getBans().get(4).getChampionId()).isEqualTo("8");
-        assertThat(dto.getBans().get(4).getPickTurn()).isEqualTo("1");
+        assertThat(dto.getBans().get(0).getChampionId()).isEqualTo(220);
+        assertThat(dto.getBans().get(0).getPickTurn()).isEqualTo(2);
+        assertThat(dto.getBans().get(1).getChampionId()).isEqualTo(2);
+        assertThat(dto.getBans().get(1).getPickTurn()).isEqualTo(3);
+        assertThat(dto.getBans().get(2).getChampionId()).isEqualTo(199);
+        assertThat(dto.getBans().get(2).getPickTurn()).isEqualTo(4);
+        assertThat(dto.getBans().get(3).getChampionId()).isEqualTo(50);
+        assertThat(dto.getBans().get(3).getPickTurn()).isEqualTo(5);
+        assertThat(dto.getBans().get(4).getChampionId()).isEqualTo(8);
+        assertThat(dto.getBans().get(4).getPickTurn()).isEqualTo(1);
 
         assertThat(dto.getObjectives().getBaron().isFirst()).isFalse();
         assertThat(dto.getObjectives().getBaron().getKills()).isEqualTo(3);
@@ -130,13 +130,13 @@ public class TeamDtoTest {
         return new TeamEntity(new TeamId("KR_5976412008", 100 ), true, new Timestamp(System.currentTimeMillis()));
     }
 
-    List<BanDto> createTestBanDtoList() {
-        List<BanDto> list = new ArrayList<>();
-        list.add(new BanDto(new MatchBanEntity(new MatchBanId("KR_5976412008", 1, 100), 221, new Timestamp(System.currentTimeMillis()))));
-        list.add(new BanDto(new MatchBanEntity(new MatchBanId("KR_5976412008", 2, 100), -1, new Timestamp(System.currentTimeMillis()))));
-        list.add(new BanDto(new MatchBanEntity(new MatchBanId("KR_5976412008", 3, 100), 200, new Timestamp(System.currentTimeMillis()))));
-        list.add(new BanDto(new MatchBanEntity(new MatchBanId("KR_5976412008", 4, 100), 55, new Timestamp(System.currentTimeMillis()))));
-        list.add(new BanDto(new MatchBanEntity(new MatchBanId("KR_5976412008", 5, 100), 10, new Timestamp(System.currentTimeMillis()))));
+    List<MatchBanDto> createTestMatchBanDtoList() {
+        List<MatchBanDto> list = new ArrayList<>();
+        list.add(new MatchBanDto("KR_5976412008", 1, 100, 221));
+        list.add(new MatchBanDto("KR_5976412008", 2, 100, -1));
+        list.add(new MatchBanDto("KR_5976412008", 3, 100, 200));
+        list.add(new MatchBanDto("KR_5976412008", 4, 100, 55));
+        list.add(new MatchBanDto("KR_5976412008", 5, 100, 10));
         return list;
     }
 

--- a/inlol/src/test/java/dev/saariselka/inlol/service/MatchBanServiceTest.java
+++ b/inlol/src/test/java/dev/saariselka/inlol/service/MatchBanServiceTest.java
@@ -3,6 +3,8 @@ package dev.saariselka.inlol.service;
 import dev.saariselka.inlol.entity.MatchBanEntity;
 import dev.saariselka.inlol.entity.MatchBanId;
 import dev.saariselka.inlol.repository.MatchBanRepository;
+import dev.saariselka.inlol.vo.MatchBanVO;
+import dev.saariselka.inlol.vo.VOMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,6 +25,8 @@ public class MatchBanServiceTest {
     private MatchBanService matchBanService;
     @Autowired
     private MatchBanRepository matchBanRepository;
+    @Autowired
+    VOMapper voMapper;
 
     @Test
     @DisplayName("Insert Entity")
@@ -38,15 +42,17 @@ public class MatchBanServiceTest {
         matchBanService.insert(matchId,pickTurn,teamId,championId,rrt);
 
         // then
-        MatchBanEntity matchBanEntitySaved = matchBanRepository.findByMatchBanId(new MatchBanId(matchId,pickTurn,teamId)).get(0);
+        MatchBanVO matchBanVOSaved = voMapper.toMatchBanVOList(matchBanRepository.findByMatchBanId(new MatchBanId(matchId,pickTurn,teamId))).get(0);
 
-        assertThat(new MatchBanId(matchId, pickTurn, teamId)).isEqualTo(matchBanEntitySaved.getMatchBanId());
-        assertThat(matchBanEntitySaved.getMatchBanId()).isNotNull();
+        assertThat(matchBanVOSaved.getMatchId()).isEqualTo(matchId);
+        assertThat(matchBanVOSaved.getPickTurn()).isEqualTo(pickTurn);
+        assertThat(matchBanVOSaved.getTeamId()).isEqualTo(teamId);
+        assertThat(matchBanVOSaved.getChampionId()).isEqualTo(championId);
         assertThat(matchBanRepository.count()).isGreaterThan(0);
     }
 
     @Test
-    @DisplayName("Find Entity By MatchBanId")
+    @DisplayName("Find VO By MatchBanId")
     public void findByMatchBanId() {
         // given
         String matchId = "KR_5804413147";
@@ -66,19 +72,19 @@ public class MatchBanServiceTest {
         MatchBanEntity matchBanEntitySavedSecond = matchBanRepository.save(matchBanEntitySecond);
 
         // when
-        MatchBanEntity matchBanEntityFindFirst = matchBanService.findByMatchBanId(matchBanEntitySavedFirst.getMatchBanId()).get(0);
-        MatchBanEntity matchBanEntityFindSecond = matchBanService.findByMatchBanId(matchBanEntitySavedSecond.getMatchBanId()).get(0);
+        MatchBanVO matchBanVOFindFirst = matchBanService.findByMatchBanId(matchBanEntitySavedFirst.getMatchBanId()).get(0);
+        MatchBanVO matchBanVOFindSecond = matchBanService.findByMatchBanId(matchBanEntitySavedSecond.getMatchBanId()).get(0);
 
         // then
         assertThat(matchBanRepository.count()).isGreaterThan(0);
-        assertThat(matchBanEntityFindFirst.getMatchBanId().getPickTurn()).isEqualTo(1);
-        assertThat(matchBanEntityFindFirst.getChampionId()).isEqualTo(99);
-        assertThat(matchBanEntityFindSecond.getMatchBanId().getPickTurn()).isEqualTo(2);
-        assertThat(matchBanEntityFindSecond.getChampionId()).isEqualTo(100);
+        assertThat(matchBanVOFindFirst.getPickTurn()).isEqualTo(1);
+        assertThat(matchBanVOFindFirst.getChampionId()).isEqualTo(99);
+        assertThat(matchBanVOFindSecond.getPickTurn()).isEqualTo(2);
+        assertThat(matchBanVOFindSecond.getChampionId()).isEqualTo(100);
     }
 
     @Test
-    @DisplayName("Find Entity By MatchBanId.MatchId")
+    @DisplayName("Find VO By MatchId")
     public void findByMatchId() {
         // given
         String matchIdFirst = "KR_5804413147";
@@ -99,19 +105,19 @@ public class MatchBanServiceTest {
         MatchBanEntity matchBanEntitySavedSecond = matchBanRepository.save(matchBanEntitySecond);
 
         // when
-        MatchBanEntity matchBanEntityFindFirst = matchBanService.findByMatchId(matchBanEntitySavedFirst.getMatchBanId().getMatchId()).get(0);
-        MatchBanEntity matchBanEntityFindSecond = matchBanService.findByMatchId(matchBanEntitySavedSecond.getMatchBanId().getMatchId()).get(0);
+        MatchBanVO matchBanVOFindFirst = matchBanService.findByMatchId(matchBanEntitySavedFirst.getMatchBanId().getMatchId()).get(0);
+        MatchBanVO matchBanVOFindSecond = matchBanService.findByMatchId(matchBanEntitySavedSecond.getMatchBanId().getMatchId()).get(0);
 
         // then
         assertThat(matchBanRepository.count()).isGreaterThan(0);
-        assertThat(matchBanEntityFindFirst.getMatchBanId().getMatchId()).isEqualTo("KR_5804413147");
-        assertThat(matchBanEntityFindFirst.getChampionId()).isEqualTo(99);
-        assertThat(matchBanEntityFindSecond.getMatchBanId().getMatchId()).isEqualTo("KR_5804413148");
-        assertThat(matchBanEntityFindSecond.getChampionId()).isEqualTo(100);
+        assertThat(matchBanVOFindFirst.getMatchId()).isEqualTo("KR_5804413147");
+        assertThat(matchBanVOFindFirst.getChampionId()).isEqualTo(99);
+        assertThat(matchBanVOFindSecond.getMatchId()).isEqualTo("KR_5804413148");
+        assertThat(matchBanVOFindSecond.getChampionId()).isEqualTo(100);
     }
 
     @Test
-    @DisplayName("Find Entity By MatchBanId.MatchId, MatchBanId.TeamId")
+    @DisplayName("Find VO By MatchId, TeamId")
     public void findByMatchIdAndTeamId() {
         // given
         String matchId = "KR_5804413147";
@@ -131,15 +137,15 @@ public class MatchBanServiceTest {
         MatchBanEntity matchBanEntitySavedSecond = matchBanRepository.save(matchBanEntitySecond);
 
         // when
-        MatchBanEntity matchBanEntityFindFirst = matchBanService.findByMatchIdAndTeamId(matchBanEntitySavedFirst.getMatchBanId().getMatchId(),matchBanEntitySavedFirst.getMatchBanId().getTeamId()).get(0);
-        MatchBanEntity matchBanEntityFindSecond = matchBanService.findByMatchIdAndTeamId(matchBanEntitySavedSecond.getMatchBanId().getMatchId(),matchBanEntitySavedSecond.getMatchBanId().getTeamId()).get(0);
+        MatchBanVO matchBanVOFindFirst = matchBanService.findByMatchIdAndTeamId(matchBanEntitySavedFirst.getMatchBanId().getMatchId(),matchBanEntitySavedFirst.getMatchBanId().getTeamId()).get(0);
+        MatchBanVO matchBanVOFindSecond = matchBanService.findByMatchIdAndTeamId(matchBanEntitySavedSecond.getMatchBanId().getMatchId(),matchBanEntitySavedSecond.getMatchBanId().getTeamId()).get(0);
 
         // then
         assertThat(matchBanRepository.count()).isGreaterThan(0);
-        assertThat(matchBanEntityFindFirst.getMatchBanId().getMatchId()).isEqualTo("KR_5804413147");
-        assertThat(matchBanEntityFindFirst.getMatchBanId().getTeamId()).isEqualTo(100);
-        assertThat(matchBanEntityFindSecond.getMatchBanId().getMatchId()).isEqualTo("KR_5804413147");
-        assertThat(matchBanEntityFindSecond.getMatchBanId().getTeamId()).isEqualTo(200);
+        assertThat(matchBanVOFindFirst.getMatchId()).isEqualTo("KR_5804413147");
+        assertThat(matchBanVOFindFirst.getTeamId()).isEqualTo(100);
+        assertThat(matchBanVOFindSecond.getMatchId()).isEqualTo("KR_5804413147");
+        assertThat(matchBanVOFindSecond.getTeamId()).isEqualTo(200);
     }
 }
 

--- a/inlol/src/test/java/dev/saariselka/inlol/vo/MatchBanVOTest.java
+++ b/inlol/src/test/java/dev/saariselka/inlol/vo/MatchBanVOTest.java
@@ -1,0 +1,47 @@
+package dev.saariselka.inlol.vo;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MatchBanVOTest {
+
+    @Test
+    @DisplayName("MatchBanVO Lombok Get Function")
+    public void testLombokGetFunction() {
+
+        //given
+        String matchId = "KR_5804413147";
+        int pickTurn = 1;
+        int teamId = 100;
+        int championId = 99;
+
+        //when
+        MatchBanVO matchBanVO = new MatchBanVO(matchId, pickTurn, teamId, championId);
+
+        //then
+        assertThat(matchBanVO.getMatchId()).isEqualTo(matchId);
+        assertThat(matchBanVO.getPickTurn()).isEqualTo(pickTurn);
+        assertThat(matchBanVO.getTeamId()).isEqualTo(teamId);
+        assertThat(matchBanVO.getChampionId()).isEqualTo(championId);
+    }
+
+    @Test
+    @DisplayName("MatchBanVO Lombok Set Function")
+    public void testLombokSetFunction() {
+        //given
+        String matchId = "KR_5804413147";
+        int pickTurn = 1;
+        int teamId = 100;
+        int championId = 99;
+        MatchBanVO matchBanVO = new MatchBanVO(matchId, pickTurn, teamId, championId);
+
+        //when
+        int testChampionId = 100;
+        matchBanVO.setChampionId(testChampionId);
+
+        //then
+        assertThat(matchBanVO.getChampionId()).isEqualTo(testChampionId);
+    }
+}

--- a/inlol/src/test/java/dev/saariselka/inlol/vo/VOMapperTest.java
+++ b/inlol/src/test/java/dev/saariselka/inlol/vo/VOMapperTest.java
@@ -1,12 +1,15 @@
 package dev.saariselka.inlol.vo;
 
 import dev.saariselka.inlol.dto.SummonerSpellDto;
+import dev.saariselka.inlol.entity.MatchBanEntity;
+import dev.saariselka.inlol.entity.MatchBanId;
 import dev.saariselka.inlol.entity.SummonerSpellEntity;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -43,7 +46,7 @@ public class VOMapperTest {
     }
 
     @Test
-    @DisplayName("Convert SummonerSpellDtoList To SummonerSpellVOList")
+    @DisplayName("Convert SummonerSpellEntityList To SummonerSpellVOList")
     public void toSummonerSpellVOList() {
 
         //given
@@ -64,5 +67,54 @@ public class VOMapperTest {
         assertThat(summonerSpellVOList.get(0).getDescription()).isEqualTo(description);
         assertThat(summonerSpellVOList.get(0).getSpellKey()).isEqualTo(spellKey);
         assertThat(summonerSpellVOList.get(0).getImage()).isEqualTo(image);
+    }
+
+    @Test
+    @DisplayName("Convert MatchBanVOList To MatchBanEntityList")
+    public void toMatchBanEntityList() {
+
+        //given
+        String matchId = "KR_5804413147";
+        int pickTurn = 1;
+        int teamId = 100;
+        int championId = 99;
+        MatchBanVO matchBanVO = new MatchBanVO(matchId,pickTurn,teamId,championId);
+        List<MatchBanVO> matchBanVOList = new ArrayList<>();
+        matchBanVOList.add(matchBanVO);
+
+        //when
+        List<MatchBanEntity> matchBanEntityList = new ArrayList<>();
+        matchBanEntityList = voMapper.toMatchBanEntityList(matchBanVOList);
+
+        //then
+        assertThat(matchBanEntityList.get(0).getMatchBanId().getMatchId()).isEqualTo(matchId);
+        assertThat(matchBanEntityList.get(0).getMatchBanId().getPickTurn()).isEqualTo(pickTurn);
+        assertThat(matchBanEntityList.get(0).getMatchBanId().getTeamId()).isEqualTo(teamId);
+        assertThat(matchBanEntityList.get(0).getChampionId()).isEqualTo(championId);
+    }
+
+    @Test
+    @DisplayName("Convert MatchBanEntityList To MatchBanVOList")
+    public void toMatchBanVOList() {
+
+        //given
+        String matchId = "KR_5804413147";
+        int pickTurn = 1;
+        int teamId = 100;
+        int championId = 99;
+        Timestamp rrt = new Timestamp(System.currentTimeMillis());
+        MatchBanEntity matchBanEntity = new MatchBanEntity(new MatchBanId(matchId,pickTurn,teamId),championId,rrt);
+        List<MatchBanEntity> matchBanEntityList = new ArrayList<>();
+        matchBanEntityList.add(matchBanEntity);
+
+        //when
+        List<MatchBanVO> matchBanVOList = new ArrayList<>();
+        matchBanVOList = voMapper.toMatchBanVOList(matchBanEntityList);
+
+        //then
+        assertThat(matchBanVOList.get(0).getMatchId()).isEqualTo(matchId);
+        assertThat(matchBanVOList.get(0).getPickTurn()).isEqualTo(pickTurn);
+        assertThat(matchBanVOList.get(0).getTeamId()).isEqualTo(teamId);
+        assertThat(matchBanVOList.get(0).getChampionId()).isEqualTo(championId);
     }
 }


### PR DESCRIPTION
- new
  . MatchBan Dto, VO
- change
  . MatchBan Controller, Service 內 Entity 제거
  . DtoMapper, VOMapper 內 MachBan Dto, VO 관련 신규 method 추가
  . Entity -> Dto 구조 변경에 따라 DBFacade(Facade_Get)에서 Entity로 BanDto List 생성하는 로직 삭제 후, MatchBanDto List 로 TeamDto 구성하도록 수정
  . 위의 사유에 따라 TeamDto 변수 중 BanDto -> MatchBanDto로 변경