### PR TITLE
LeagueEntry Entity 제거 관련 변경

### DIFF
--- a/inlol/src/main/java/dev/saariselka/inlol/controller/DtoMapper.java
+++ b/inlol/src/main/java/dev/saariselka/inlol/controller/DtoMapper.java
@@ -270,4 +270,36 @@ public class DtoMapper {
         }
         return dtoList;
     }
+
+    public List<LeagueEntryDto> toLeagueEntryDtoList(List<LeagueEntryVO> leagueEntryVOList) {
+        List<LeagueEntryDto> leagueEntryDtoList = new ArrayList<>();
+
+        for(LeagueEntryVO leagueEntryVO : leagueEntryVOList) {
+            LeagueEntryDto leagueEntryDto = new LeagueEntryDto();
+
+            leagueEntryDto.setSummonerId(leagueEntryVO.getSummonerId());
+            leagueEntryDto.setQueueType(leagueEntryVO.getQueueType());
+            leagueEntryDto.setLeagueId(leagueEntryVO.getLeagueId());
+            leagueEntryDto.setSummonerName(leagueEntryVO.getSummonerName());
+            leagueEntryDto.setLeaguePoints(leagueEntryVO.getLeaguePoints());
+            leagueEntryDto.setTier(leagueEntryVO.getTier());
+            if(leagueEntryVO.getTier().equals("MASTER")||leagueEntryVO.getTier().equals("GRANDMASTER")||leagueEntryVO.getTier().equals("CHALLENGER"))
+            {
+                leagueEntryDto.setRank("");
+            }
+            else {
+                leagueEntryDto.setRank(leagueEntryVO.getRanks());
+            }
+            leagueEntryDto.setWins(leagueEntryVO.getWins());
+            leagueEntryDto.setLosses(leagueEntryVO.getLosses());
+            leagueEntryDto.setHotStreak(leagueEntryVO.isHotStreak());
+            leagueEntryDto.setVeteran(leagueEntryVO.isVeteran());
+            leagueEntryDto.setFreshBlood(leagueEntryVO.isFreshBlood());
+            leagueEntryDto.setInactive(leagueEntryVO.isInactive());
+
+            leagueEntryDtoList.add(leagueEntryDto);
+        }
+
+        return leagueEntryDtoList;
+    }
 }

--- a/inlol/src/main/java/dev/saariselka/inlol/controller/LeagueEntryController.java
+++ b/inlol/src/main/java/dev/saariselka/inlol/controller/LeagueEntryController.java
@@ -1,5 +1,6 @@
 package dev.saariselka.inlol.controller;
 
+import dev.saariselka.inlol.dto.LeagueEntryDto;
 import dev.saariselka.inlol.entity.LeagueEntryEntity;
 import dev.saariselka.inlol.entity.LeagueEntryId;
 import dev.saariselka.inlol.service.LeagueEntryService;
@@ -21,13 +22,15 @@ public class LeagueEntryController {
 
     @Autowired
     LeagueEntryService leagueEntryService;
+    @Autowired
+    DtoMapper dtoMapper;
 
-    public List<LeagueEntryEntity> getLeagueEntriesByLeagueEntryId(String summonerId, String queueType) {
-        return leagueEntryService.findByLeagueEntryId(new LeagueEntryId(summonerId, queueType));
+    public List<LeagueEntryDto> getLeagueEntriesByLeagueEntryId(String summonerId, String queueType) {
+        return dtoMapper.toLeagueEntryDtoList(leagueEntryService.findByLeagueEntryId(new LeagueEntryId(summonerId, queueType)));
     }
 
-    public List<LeagueEntryEntity> getLeagueEntriesBySummonerId(String summonerId) {
-        return leagueEntryService.findByLeagueEntryId_SummonerId(summonerId);
+    public List<LeagueEntryDto> getLeagueEntriesBySummonerId(String summonerId) {
+        return dtoMapper.toLeagueEntryDtoList(leagueEntryService.findByLeagueEntryId_SummonerId(summonerId));
     }
 
     public void insertLeagueEntryInfo(String summonerId, String queueType, String leagueId, String summonerName, String tier, String rank, int leaguePoints, int wins, int losses, boolean hotStreak, boolean veteran, boolean freshBlood, boolean inactive, Timestamp rrt) {

--- a/inlol/src/main/java/dev/saariselka/inlol/facade/DBFacade.java
+++ b/inlol/src/main/java/dev/saariselka/inlol/facade/DBFacade.java
@@ -134,20 +134,17 @@ public class DBFacade {
 
     }
 
-    public ArrayList<LeagueEntryDto> getLeagueEntryDtoListBySummonerId(String summonerId) {
-        ArrayList<LeagueEntryDto> result = new ArrayList<>();
+    public List<LeagueEntryDto> getLeagueEntryDtoListBySummonerId(String summonerId) {
+        List<LeagueEntryDto> leagueEntryDtoList = leagueEntryController.getLeagueEntriesBySummonerId(summonerId);
 
-        List<LeagueEntryEntity> leagueEntryEntityList = leagueEntryController.getLeagueEntriesBySummonerId(summonerId);
+        for(LeagueEntryDto leagueEntryDto : leagueEntryDtoList) {
 
-        for(LeagueEntryEntity leagueEntryEntity : leagueEntryEntityList) {
+            LeagueMiniSeriesDto leagueMiniSeriesDto = leagueMiniSeriesController.getLeagueMiniSeriesEntries_ByLeagueMiniSeriesId(summonerId,leagueEntryDto.getQueueType());
 
-            LeagueMiniSeriesDto leagueMiniSeriesDto = leagueMiniSeriesController.getLeagueMiniSeriesEntries_ByLeagueMiniSeriesId(summonerId,leagueEntryEntity.getLeagueEntryId().getQueueType());
-
-            LeagueEntryDto leagueEntryDto = new LeagueEntryDto(leagueEntryEntity, leagueMiniSeriesDto);
-            result.add(leagueEntryDto);
+            leagueEntryDto.setMiniSeries(leagueMiniSeriesDto);
         }
 
-        return result;
+        return leagueEntryDtoList;
     }
 
     public ArrayList<MatchDto> getMatchDtoListBySummonerPuuid(String puuid) throws IOException {

--- a/inlol/src/main/java/dev/saariselka/inlol/service/LeagueEntryService.java
+++ b/inlol/src/main/java/dev/saariselka/inlol/service/LeagueEntryService.java
@@ -3,6 +3,7 @@ package dev.saariselka.inlol.service;
 import dev.saariselka.inlol.entity.LeagueEntryEntity;
 import dev.saariselka.inlol.entity.LeagueEntryId;
 import dev.saariselka.inlol.repository.LeagueEntryRepository;
+import dev.saariselka.inlol.vo.LeagueEntryVO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -16,13 +17,15 @@ public class LeagueEntryService {
 
     @Autowired
     private final LeagueEntryRepository leagueEntryRepository;
+    @Autowired
+    private VOMapper voMapper;
 
-    public List<LeagueEntryEntity> findByLeagueEntryId(LeagueEntryId leagueEntryId) {
-        return leagueEntryRepository.findByLeagueEntryId(leagueEntryId);
+    public List<LeagueEntryVO> findByLeagueEntryId(LeagueEntryId leagueEntryId) {
+        return voMapper.toLeagueEntryVOList(leagueEntryRepository.findByLeagueEntryId(leagueEntryId));
     }
 
-    public List<LeagueEntryEntity> findByLeagueEntryId_SummonerId(String summonerId) {
-        return leagueEntryRepository.findByLeagueEntryId_SummonerId(summonerId);
+    public List<LeagueEntryVO> findByLeagueEntryId_SummonerId(String summonerId) {
+        return voMapper.toLeagueEntryVOList(leagueEntryRepository.findByLeagueEntryId_SummonerId(summonerId));
     }
 
     public void insert(String summonerId, String queueType, String leagueId, String summonerName, String tier, String ranks, int leaguePoints, int wins, int losses, boolean hotStreak, boolean veteran, boolean freshBlood, boolean inactive, Timestamp rrt) {

--- a/inlol/src/main/java/dev/saariselka/inlol/service/VOMapper.java
+++ b/inlol/src/main/java/dev/saariselka/inlol/service/VOMapper.java
@@ -270,4 +270,17 @@ public class VOMapper {
         return voList;
     }
 
+    public List<LeagueEntryVO> toLeagueEntryVOList(List<LeagueEntryEntity> leagueEntryEntityList) {
+        List<LeagueEntryVO> leagueEntryVOList = new ArrayList<>();
+
+        for(LeagueEntryEntity leagueEntryEntity  : leagueEntryEntityList) {
+            LeagueEntryVO leagueEntryVO = new LeagueEntryVO(leagueEntryEntity.getLeagueEntryId().getSummonerId(),leagueEntryEntity.getLeagueEntryId().getQueueType(),
+                    leagueEntryEntity.getLeagueId(),leagueEntryEntity.getSummonerName(),leagueEntryEntity.getTier(),leagueEntryEntity.getRanks(),leagueEntryEntity.getLeaguePoints(),
+                    leagueEntryEntity.getWins(),leagueEntryEntity.getLosses(), leagueEntryEntity.isHotStreak(),leagueEntryEntity.isVeteran(),leagueEntryEntity.isFreshBlood(),leagueEntryEntity.isInactive());
+
+            leagueEntryVOList.add(leagueEntryVO);
+        }
+
+        return leagueEntryVOList;
+    }
 }

--- a/inlol/src/main/java/dev/saariselka/inlol/vo/LeagueEntryVO.java
+++ b/inlol/src/main/java/dev/saariselka/inlol/vo/LeagueEntryVO.java
@@ -1,0 +1,27 @@
+package dev.saariselka.inlol.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LeagueEntryVO {
+    private String summonerId;
+    private String queueType;
+    private String leagueId;
+    private String summonerName;
+
+    private String tier;
+    private String ranks;
+    private int leaguePoints;
+    private int wins;
+    private int losses;
+    private boolean hotStreak;
+    private boolean veteran;
+    private boolean freshBlood;
+    private boolean inactive;
+}

--- a/inlol/src/test/java/dev/saariselka/inlol/controller/DtoMapperTest.java
+++ b/inlol/src/test/java/dev/saariselka/inlol/controller/DtoMapperTest.java
@@ -1,23 +1,21 @@
 package dev.saariselka.inlol.controller;
 
 import dev.saariselka.inlol.controller.DtoMapper;
-import dev.saariselka.inlol.dto.ChampionDto;
-import dev.saariselka.inlol.dto.DdragonVersionDto;
-import dev.saariselka.inlol.dto.MatchBanDto;
-import dev.saariselka.inlol.dto.SummonerSpellDto;
-import dev.saariselka.inlol.vo.ChampionVO;
-import dev.saariselka.inlol.vo.DdragonVersionVO;
-import dev.saariselka.inlol.vo.MatchBanVO;
-import dev.saariselka.inlol.vo.SummonerSpellVO;
+import dev.saariselka.inlol.dto.*;
+import dev.saariselka.inlol.entity.LeagueMiniSeriesEntity;
+import dev.saariselka.inlol.entity.LeagueMiniSeriesId;
+import dev.saariselka.inlol.vo.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.array;
 
 @SpringBootTest
 public class DtoMapperTest {
@@ -154,5 +152,58 @@ public class DtoMapperTest {
         assertThat(ddragonVersionDtoList.get(0).getId()).isEqualTo(ddragonVersionVO.getId());
         assertThat(ddragonVersionDtoList.get(0).getVersion()).isEqualTo(ddragonVersionVO.getVersion());
         assertThat(ddragonVersionDtoList.get(0).getCurrent()).isEqualTo(ddragonVersionVO.getCurrent());
+    }
+
+    @Test
+    @DisplayName("Convert LeagueMiniseriesVO To LeagueMiniseriesDto")
+    public void toLeagueMiniseriesDto(){
+        // given
+        String summonerId = "testSummonerId";
+        String queueType = "RANKED_SOLO_5x5";
+        int target = 3;
+        int wins = 2;
+        int losses = 1;
+        String progress = "Test";
+        LeagueMiniSeriesVO leagueMiniSeriesVO = new LeagueMiniSeriesVO(summonerId,queueType,losses,progress,target,wins);
+
+        //when
+        LeagueMiniSeriesDto leagueMiniSeriesDto = dtoMapper.toLeagueMiniseriesDto(leagueMiniSeriesVO);
+
+        //then
+        assertThat(leagueMiniSeriesDto.getSummonerId()).isEqualTo(summonerId);
+        assertThat(leagueMiniSeriesDto.getQueueType()).isEqualTo(queueType);
+        assertThat(leagueMiniSeriesDto.getTarget()).isEqualTo(target);
+        assertThat(leagueMiniSeriesDto.getWins()).isEqualTo(wins);
+        assertThat(leagueMiniSeriesDto.getLosses()).isEqualTo(losses);
+        assertThat(String.valueOf(leagueMiniSeriesDto.getProgress())).isEqualTo(progress);
+    }
+
+    @Test
+    @DisplayName("Convert LeagueEntryVO To LeagueEntryDto")
+    public void toLeagueEntryDtoList(){
+        // given
+        String summonerId = "testSummonerId";
+        String queueType = "RANKED_SOLO_5x5";
+        String leagueId = "05fb99f4-e149-3133-a78e-821597582f9d";
+        String summonerName = "Hide on bush";
+        String tier = "CHALLENGER";
+        String ranks = "I";
+        int leaguePoints = 1008;
+        int wins = 358;
+        int losses = 309;
+        boolean hotStreak = false;
+        boolean veteran = true;
+        boolean freshBlood = false;
+        boolean inactive = false;
+        LeagueEntryVO leagueEntryVO = new LeagueEntryVO(summonerId,queueType,leagueId,summonerName,tier,ranks,leaguePoints,wins,losses,hotStreak,veteran,freshBlood,inactive);
+        List<LeagueEntryVO> leagueEntryVOList = new ArrayList<>();
+        leagueEntryVOList.add(leagueEntryVO);
+
+        //when
+        LeagueEntryDto leagueEntryDto = dtoMapper.toLeagueEntryDtoList(leagueEntryVOList).get(0);
+
+        //then
+        assertThat(leagueEntryDto.getSummonerId()).isEqualTo(summonerId);
+        assertThat(leagueEntryDto.getQueueType()).isEqualTo(queueType);
     }
 }

--- a/inlol/src/test/java/dev/saariselka/inlol/controller/LeagueEntryControllerTest.java
+++ b/inlol/src/test/java/dev/saariselka/inlol/controller/LeagueEntryControllerTest.java
@@ -1,5 +1,6 @@
 package dev.saariselka.inlol.controller;
 
+import dev.saariselka.inlol.dto.LeagueEntryDto;
 import dev.saariselka.inlol.entity.LeagueEntryEntity;
 import dev.saariselka.inlol.entity.LeagueEntryId;
 import dev.saariselka.inlol.repository.LeagueEntryRepository;
@@ -22,6 +23,8 @@ public class LeagueEntryControllerTest {
     private LeagueEntryController leagueEntryController;
     @Autowired
     private LeagueEntryService leagueEntryService;
+    @Autowired
+    private DtoMapper dtoMapper;
 
     @Test
     @DisplayName("Insert Entity")
@@ -46,10 +49,10 @@ public class LeagueEntryControllerTest {
         leagueEntryController.insertLeagueEntryInfo(summonerId,queueType,leagueId,summonerName,tier,ranks,leaguePoints,wins,losses,hotStreak,veteran,freshBlood,inactive,rrt);
 
         // then
-        LeagueEntryEntity leagueEntryEntitySaved = leagueEntryService.findByLeagueEntryId(new LeagueEntryId(summonerId,queueType)).get(0);
+        LeagueEntryDto leagueEntryDtoSaved = dtoMapper.toLeagueEntryDtoList(leagueEntryService.findByLeagueEntryId(new LeagueEntryId(summonerId,queueType))).get(0);
 
-        assertThat(new LeagueEntryId(summonerId,queueType)).isEqualTo(leagueEntryEntitySaved.getLeagueEntryId());
-        assertThat(leagueEntryEntitySaved.getLeagueEntryId()).isNotNull();
+        assertThat(leagueEntryDtoSaved.getSummonerId()).isEqualTo(summonerId);
+        assertThat(leagueEntryDtoSaved.getQueueType()).isEqualTo(queueType);
     }
 
     @Test
@@ -89,14 +92,14 @@ public class LeagueEntryControllerTest {
         leagueEntryService.insert(summonerIdKeria,queueTypeKeria,leagueIdKeria,summonerNameKeria,tierKeria,ranksKeria,leaguePointsKeria,winsKeria,lossesKeria,hotStreakKeria,veteranKeria,freshBloodKeria,inactiveKeria,rrt);
 
         // when
-        LeagueEntryEntity leagueEntryEntityFindFaker = leagueEntryController.getLeagueEntriesByLeagueEntryId(summonerIdFaker, queueTypeFaker).get(0);
-        LeagueEntryEntity leagueEntryEntityFindKeria = leagueEntryController.getLeagueEntriesByLeagueEntryId(summonerIdKeria, queueTypeKeria).get(0);
+        LeagueEntryDto leagueEntryDtoFindFaker = leagueEntryController.getLeagueEntriesByLeagueEntryId(summonerIdFaker, queueTypeFaker).get(0);
+        LeagueEntryDto leagueEntryDtoFindKeria = leagueEntryController.getLeagueEntriesByLeagueEntryId(summonerIdKeria, queueTypeKeria).get(0);
 
         // then
-        assertThat(leagueEntryEntityFindFaker.getSummonerName()).isEqualTo("Hide on bush");
-        assertThat(leagueEntryEntityFindFaker.getLeaguePoints()).isEqualTo(1008);
-        assertThat(leagueEntryEntityFindKeria.getSummonerName()).isEqualTo("역천괴");
-        assertThat(leagueEntryEntityFindKeria.getLeaguePoints()).isEqualTo(1002);
+        assertThat(leagueEntryDtoFindFaker.getSummonerName()).isEqualTo("Hide on bush");
+        assertThat(leagueEntryDtoFindFaker.getLeaguePoints()).isEqualTo(1008);
+        assertThat(leagueEntryDtoFindKeria.getSummonerName()).isEqualTo("역천괴");
+        assertThat(leagueEntryDtoFindKeria.getLeaguePoints()).isEqualTo(1002);
     }
 
     @Test
@@ -136,13 +139,13 @@ public class LeagueEntryControllerTest {
         leagueEntryService.insert(summonerIdKeria,queueTypeKeria,leagueIdKeria,summonerNameKeria,tierKeria,ranksKeria,leaguePointsKeria,winsKeria,lossesKeria,hotStreakKeria,veteranKeria,freshBloodKeria,inactiveKeria,rrt);
 
         // when
-        LeagueEntryEntity leagueEntryEntityFindFaker = leagueEntryController.getLeagueEntriesBySummonerId(summonerIdFaker).get(0);
-        LeagueEntryEntity leagueEntryEntityFindKeria = leagueEntryController.getLeagueEntriesBySummonerId(summonerIdKeria).get(0);
+        LeagueEntryDto leagueEntryDtoFindFaker = leagueEntryController.getLeagueEntriesByLeagueEntryId(summonerIdFaker, queueTypeFaker).get(0);
+        LeagueEntryDto leagueEntryDtoFindKeria = leagueEntryController.getLeagueEntriesByLeagueEntryId(summonerIdKeria, queueTypeKeria).get(0);
 
         // then
-        assertThat(leagueEntryEntityFindFaker.getSummonerName()).isEqualTo("Hide on bush");
-        assertThat(leagueEntryEntityFindFaker.getLeaguePoints()).isEqualTo(1008);
-        assertThat(leagueEntryEntityFindKeria.getSummonerName()).isEqualTo("역천괴");
-        assertThat(leagueEntryEntityFindKeria.getLeaguePoints()).isEqualTo(1002);
+        assertThat(leagueEntryDtoFindFaker.getSummonerName()).isEqualTo("Hide on bush");
+        assertThat(leagueEntryDtoFindFaker.getLeaguePoints()).isEqualTo(1008);
+        assertThat(leagueEntryDtoFindKeria.getSummonerName()).isEqualTo("역천괴");
+        assertThat(leagueEntryDtoFindKeria.getLeaguePoints()).isEqualTo(1002);
     }
 }

--- a/inlol/src/test/java/dev/saariselka/inlol/dto/LeagueEntryDtoTest.java
+++ b/inlol/src/test/java/dev/saariselka/inlol/dto/LeagueEntryDtoTest.java
@@ -23,7 +23,6 @@ public class LeagueEntryDtoTest {
         String progress = "Test";
         int target = 3;
         int leagueMiniSeries_wins = 1;
-        Timestamp rrt = new Timestamp(System.currentTimeMillis());
 
         String leagueId = "TestLeagueId";
         String summonerName = "TestName";
@@ -37,11 +36,24 @@ public class LeagueEntryDtoTest {
         boolean freshBlood = false;
         boolean inactive = false;
 
-        LeagueEntryEntity leagueEntryEntity = new LeagueEntryEntity(new LeagueEntryId(summonerId,queueType),leagueId,summonerName,tier,ranks,leaguePoints,leagueEntry_wins,leagueEntry_losses,hotStreak,veteran,freshBlood,inactive,rrt);
         LeagueMiniSeriesDto leagueMiniSeriesDto = new LeagueMiniSeriesDto(summonerId,queueType,leagueMiniSeries_wins,leagueMiniSeries_losses,target,progress.toCharArray());
 
         // When
-        LeagueEntryDto leagueEntryDto = new LeagueEntryDto(leagueEntryEntity,leagueMiniSeriesDto);
+        LeagueEntryDto leagueEntryDto = new LeagueEntryDto();
+        leagueEntryDto.setLeagueId(leagueId);
+        leagueEntryDto.setSummonerName(summonerName);
+        leagueEntryDto.setSummonerId(summonerId);
+        leagueEntryDto.setQueueType(queueType);
+        leagueEntryDto.setLeaguePoints(leaguePoints);
+        leagueEntryDto.setTier(tier);
+        leagueEntryDto.setRank(ranks);
+        leagueEntryDto.setWins(leagueEntry_wins);
+        leagueEntryDto.setLosses(leagueEntry_losses);
+        leagueEntryDto.setHotStreak(hotStreak);
+        leagueEntryDto.setVeteran(veteran);
+        leagueEntryDto.setFreshBlood(freshBlood);
+        leagueEntryDto.setInactive(inactive);
+        leagueEntryDto.setMiniSeries(leagueMiniSeriesDto);
 
         // Then
         assertThat(leagueEntryDto.getSummonerId()).isEqualTo(summonerId);
@@ -95,8 +107,21 @@ public class LeagueEntryDtoTest {
 
         LeagueMiniSeriesDto leagueMiniSeriesDto = new LeagueMiniSeriesDto(summonerId,queueType,leagueMiniSeries_wins,leagueMiniSeries_losses,target,progress.toCharArray());
         LeagueMiniSeriesDto tobe_leagueMiniSeriesDto = new LeagueMiniSeriesDto(tobe_summonerId,tobe_queueType,tobe_leagueMiniSeries_wins,tobe_leagueMiniSeries_losses,tobe_target,tobe_progress.toCharArray());
-        LeagueEntryEntity leagueEntryEntity = new LeagueEntryEntity(new LeagueEntryId(summonerId,queueType),leagueId,summonerName,tier,ranks,leaguePoints,leagueEntry_wins,leagueEntry_losses,hotStreak,veteran,freshBlood,inactive,rrt);
-        LeagueEntryDto leagueEntryDto = new LeagueEntryDto(leagueEntryEntity,leagueMiniSeriesDto);
+        LeagueEntryDto leagueEntryDto = new LeagueEntryDto();
+        leagueEntryDto.setLeagueId(leagueId);
+        leagueEntryDto.setSummonerName(summonerName);
+        leagueEntryDto.setSummonerId(summonerId);
+        leagueEntryDto.setQueueType(queueType);
+        leagueEntryDto.setLeaguePoints(leaguePoints);
+        leagueEntryDto.setTier(tier);
+        leagueEntryDto.setRank(ranks);
+        leagueEntryDto.setWins(leagueEntry_wins);
+        leagueEntryDto.setLosses(leagueEntry_losses);
+        leagueEntryDto.setHotStreak(hotStreak);
+        leagueEntryDto.setVeteran(veteran);
+        leagueEntryDto.setFreshBlood(freshBlood);
+        leagueEntryDto.setInactive(inactive);
+        leagueEntryDto.setMiniSeries(leagueMiniSeriesDto);
 
         // When
         leagueEntryDto.setSummonerId(tobe_summonerId);

--- a/inlol/src/test/java/dev/saariselka/inlol/facade/DBFacadeTest.java
+++ b/inlol/src/test/java/dev/saariselka/inlol/facade/DBFacadeTest.java
@@ -237,15 +237,15 @@ public class DBFacadeTest {
 
         // when
         dbFacade.setLeagueInfo(leagueInfos);
-        LeagueEntryEntity find = leagueEntryController.getLeagueEntriesBySummonerId("TestSummonerId").get(0);
+        LeagueEntryDto find = leagueEntryController.getLeagueEntriesBySummonerId("TestSummonerId").get(0);
 
         // then
-        assertThat(find.getLeagueEntryId().getSummonerId()).isEqualTo("TestSummonerId");
-        assertThat(find.getLeagueEntryId().getQueueType()).isEqualTo("RANKED_SOLO_5x5");
+        assertThat(find.getSummonerId()).isEqualTo("TestSummonerId");
+        assertThat(find.getQueueType()).isEqualTo("RANKED_SOLO_5x5");
         assertThat(find.getLeagueId()).isEqualTo("TestLeagueId");
         assertThat(find.getSummonerName()).isEqualTo("TestUser");
         assertThat(find.getTier()).isEqualTo("TestTier");
-        assertThat(find.getRanks()).isEqualTo("II");
+        assertThat(find.getRank()).isEqualTo("II");
         assertThat(find.getLeaguePoints()).isEqualTo(99);
         assertThat(find.getWins()).isEqualTo(0);
         assertThat(find.getLosses()).isEqualTo(0);
@@ -263,15 +263,15 @@ public class DBFacadeTest {
 
         // when
         dbFacade.setLeagueInfo(leagueInfos);
-        LeagueEntryEntity find = leagueEntryController.getLeagueEntriesBySummonerId("TestSummonerId").get(0);
+        LeagueEntryDto find = leagueEntryController.getLeagueEntriesBySummonerId("TestSummonerId").get(0);
 
         // then
-        assertThat(find.getLeagueEntryId().getSummonerId()).isEqualTo("TestSummonerId");
-        assertThat(find.getLeagueEntryId().getQueueType()).isEqualTo("RANKED_FLEX_SR");
+        assertThat(find.getSummonerId()).isEqualTo("TestSummonerId");
+        assertThat(find.getQueueType()).isEqualTo("RANKED_FLEX_SR");
         assertThat(find.getLeagueId()).isEqualTo("TestLeagueId");
         assertThat(find.getSummonerName()).isEqualTo("TestUser");
         assertThat(find.getTier()).isEqualTo("TestTier");
-        assertThat(find.getRanks()).isEqualTo("II");
+        assertThat(find.getRank()).isEqualTo("II");
         assertThat(find.getLeaguePoints()).isEqualTo(99);
         assertThat(find.getWins()).isEqualTo(0);
         assertThat(find.getLosses()).isEqualTo(0);
@@ -290,7 +290,7 @@ public class DBFacadeTest {
 
         // when
         dbFacade.setLeagueInfo(leagueInfos);
-        List<LeagueEntryEntity> find = leagueEntryController.getLeagueEntriesBySummonerId("TestSummonerId");
+        List<LeagueEntryDto> find = leagueEntryController.getLeagueEntriesBySummonerId("TestSummonerId");
 
         // then
         assertThat(find.isEmpty()).isTrue();
@@ -304,16 +304,16 @@ public class DBFacadeTest {
 
         // when
         dbFacade.setLeagueInfo(leagueInfos);
-        LeagueEntryEntity find = leagueEntryController.getLeagueEntriesBySummonerId("TestSummonerId").get(0);
+        LeagueEntryDto find = leagueEntryController.getLeagueEntriesBySummonerId("TestSummonerId").get(0);
         LeagueMiniSeriesDto miniFind = leagueMiniSeriesController.getLeagueMiniSeriesEntries_ByLeagueMiniSeriesId("TestSummonerId", "RANKED_SOLO_5x5");
 
         // then
-        assertThat(find.getLeagueEntryId().getSummonerId()).isEqualTo("TestSummonerId");
-        assertThat(find.getLeagueEntryId().getQueueType()).isEqualTo("RANKED_SOLO_5x5");
+        assertThat(find.getSummonerId()).isEqualTo("TestSummonerId");
+        assertThat(find.getQueueType()).isEqualTo("RANKED_SOLO_5x5");
         assertThat(find.getLeagueId()).isEqualTo("TestLeagueId");
         assertThat(find.getSummonerName()).isEqualTo("TestUser");
         assertThat(find.getTier()).isEqualTo("TestTier");
-        assertThat(find.getRanks()).isEqualTo("I");
+        assertThat(find.getRank()).isEqualTo("I");
         assertThat(find.getLeaguePoints()).isEqualTo(100);
         assertThat(find.getWins()).isEqualTo(2);
         assertThat(find.getLosses()).isEqualTo(1);
@@ -337,16 +337,16 @@ public class DBFacadeTest {
 
         // when
         dbFacade.setLeagueInfo(leagueInfos);
-        LeagueEntryEntity find = leagueEntryController.getLeagueEntriesBySummonerId("TestSummonerId").get(0);
+        LeagueEntryDto find = leagueEntryController.getLeagueEntriesBySummonerId("TestSummonerId").get(0);
         LeagueMiniSeriesDto miniFind = leagueMiniSeriesController.getLeagueMiniSeriesEntries_ByLeagueMiniSeriesId("TestSummonerId", "RANKED_FLEX_SR");
 
         // then
-        assertThat(find.getLeagueEntryId().getSummonerId()).isEqualTo("TestSummonerId");
-        assertThat(find.getLeagueEntryId().getQueueType()).isEqualTo("RANKED_FLEX_SR");
+        assertThat(find.getSummonerId()).isEqualTo("TestSummonerId");
+        assertThat(find.getQueueType()).isEqualTo("RANKED_FLEX_SR");
         assertThat(find.getLeagueId()).isEqualTo("TestLeagueId");
         assertThat(find.getSummonerName()).isEqualTo("TestUser");
         assertThat(find.getTier()).isEqualTo("TestTier");
-        assertThat(find.getRanks()).isEqualTo("I");
+        assertThat(find.getRank()).isEqualTo("I");
         assertThat(find.getLeaguePoints()).isEqualTo(100);
         assertThat(find.getWins()).isEqualTo(2);
         assertThat(find.getLosses()).isEqualTo(1);
@@ -371,7 +371,7 @@ public class DBFacadeTest {
 
         // when
         dbFacade.setLeagueInfo(leagueInfos);
-        List<LeagueEntryEntity> find = leagueEntryController.getLeagueEntriesBySummonerId("TestSummonerId");
+        List<LeagueEntryDto> find = leagueEntryController.getLeagueEntriesBySummonerId("TestSummonerId");
         LeagueMiniSeriesDto miniFind = leagueMiniSeriesController.getLeagueMiniSeriesEntries_ByLeagueMiniSeriesId("TestSummonerId", "TestType");
 
         // then
@@ -575,7 +575,7 @@ public class DBFacadeTest {
 
 
         // when
-        ArrayList<LeagueEntryDto> test = dbFacade.getLeagueEntryDtoListBySummonerId(summonerId);
+        List<LeagueEntryDto> test = dbFacade.getLeagueEntryDtoListBySummonerId(summonerId);
 
         // then
         for(LeagueEntryDto dto : test) {
@@ -672,7 +672,7 @@ public class DBFacadeTest {
                 soloLeaguePoints, win, losses, soloHotStreak, soloVeteran, soloFreshBlood, soloInactive, rrt);
 
         // when
-        ArrayList<LeagueEntryDto> test = dbFacade.getLeagueEntryDtoListBySummonerId(summonerId);
+        List<LeagueEntryDto> test = dbFacade.getLeagueEntryDtoListBySummonerId(summonerId);
 
         // then
         for(LeagueEntryDto dto : test) {

--- a/inlol/src/test/java/dev/saariselka/inlol/service/LeagueEntryServiceTest.java
+++ b/inlol/src/test/java/dev/saariselka/inlol/service/LeagueEntryServiceTest.java
@@ -3,6 +3,7 @@ package dev.saariselka.inlol.service;
 import dev.saariselka.inlol.entity.LeagueEntryEntity;
 import dev.saariselka.inlol.entity.LeagueEntryId;
 import dev.saariselka.inlol.repository.LeagueEntryRepository;
+import dev.saariselka.inlol.vo.LeagueEntryVO;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,6 +22,8 @@ public class LeagueEntryServiceTest {
     private LeagueEntryService leagueEntryService;
     @Autowired
     private LeagueEntryRepository leagueEntryRepository;
+    @Autowired
+    private VOMapper voMapper;
 
     @Test
     @DisplayName("Insert Entity")
@@ -45,15 +48,15 @@ public class LeagueEntryServiceTest {
         leagueEntryService.insert(summonerId,queueType,leagueId,summonerName,tier,ranks,leaguePoints,wins,losses,hotStreak,veteran,freshBlood,inactive,rrt);
 
         // then
-        LeagueEntryEntity leagueEntryEntitySaved = leagueEntryRepository.findByLeagueEntryId(new LeagueEntryId(summonerId,queueType)).get(0);
+        LeagueEntryVO leagueEntryVOSaved = voMapper.toLeagueEntryVOList(leagueEntryRepository.findByLeagueEntryId(new LeagueEntryId(summonerId,queueType))).get(0);
 
-        assertThat(new LeagueEntryId(summonerId,queueType)).isEqualTo(leagueEntryEntitySaved.getLeagueEntryId());
-        assertThat(leagueEntryEntitySaved.getLeagueEntryId()).isNotNull();
+        assertThat(leagueEntryVOSaved.getSummonerId()).isEqualTo(summonerId);
+        assertThat(leagueEntryVOSaved.getQueueType()).isEqualTo(queueType);
         assertThat(leagueEntryRepository.count()).isGreaterThan(1);
     }
 
     @Test
-    @DisplayName("Find Entity By LeagueEntryId")
+    @DisplayName("Find VO By LeagueEntryId")
     public void findByLeagueEntryId() {
         // given
         String summonerIdFaker = "qdDRYfl_uN6Pt7V-9kSwLGoc-jNfw0hjQj0n7XT1yVrLiA";
@@ -92,19 +95,19 @@ public class LeagueEntryServiceTest {
         LeagueEntryEntity leagueEntryEntitySavedKeria = leagueEntryRepository.save(leagueEntryEntityKeria);
 
         // when
-        LeagueEntryEntity leagueEntryEntityFindFaker = leagueEntryService.findByLeagueEntryId(leagueEntryEntitySavedFaker.getLeagueEntryId()).get(0);
-        LeagueEntryEntity leagueEntryEntityFindKeria = leagueEntryService.findByLeagueEntryId(leagueEntryEntitySavedKeria.getLeagueEntryId()).get(0);
+        LeagueEntryVO leagueEntryVOFindFaker = leagueEntryService.findByLeagueEntryId(leagueEntryEntitySavedFaker.getLeagueEntryId()).get(0);
+        LeagueEntryVO leagueEntryVOFindKeria = leagueEntryService.findByLeagueEntryId(leagueEntryEntitySavedKeria.getLeagueEntryId()).get(0);
 
         // then
         assertThat(leagueEntryRepository.count()).isGreaterThan(2);
-        assertThat(leagueEntryEntityFindFaker.getSummonerName()).isEqualTo("Hide on bush");
-        assertThat(leagueEntryEntityFindFaker.getLeaguePoints()).isEqualTo(1008);
-        assertThat(leagueEntryEntityFindKeria.getSummonerName()).isEqualTo("역천괴");
-        assertThat(leagueEntryEntityFindKeria.getLeaguePoints()).isEqualTo(1002);
+        assertThat(leagueEntryVOFindFaker.getSummonerName()).isEqualTo("Hide on bush");
+        assertThat(leagueEntryVOFindFaker.getLeaguePoints()).isEqualTo(1008);
+        assertThat(leagueEntryVOFindKeria.getSummonerName()).isEqualTo("역천괴");
+        assertThat(leagueEntryVOFindKeria.getLeaguePoints()).isEqualTo(1002);
     }
 
     @Test
-    @DisplayName("Find Entity By LeagueEntryId.SummonerId")
+    @DisplayName("Find VO By LeagueEntryId.SummonerId")
     public void findByLeagueEntryId_SummonerId() {
         // given
         String summonerIdFaker = "qdDRYfl_uN6Pt7V-9kSwLGoc-jNfw0hjQj0n7XT1yVrLiA";
@@ -143,14 +146,13 @@ public class LeagueEntryServiceTest {
         LeagueEntryEntity leagueEntryEntitySavedKeria = leagueEntryRepository.save(leagueEntryEntityKeria);
 
         // when
-
-        LeagueEntryEntity leagueEntryEntityFindFaker = leagueEntryService.findByLeagueEntryId_SummonerId(leagueEntryEntitySavedFaker.getLeagueEntryId().getSummonerId()).get(0);
-        LeagueEntryEntity leagueEntryEntityFindKeria = leagueEntryService.findByLeagueEntryId_SummonerId(leagueEntryEntitySavedKeria.getLeagueEntryId().getSummonerId()).get(0);
+        LeagueEntryVO leagueEntryVOFindFaker = leagueEntryService.findByLeagueEntryId_SummonerId(leagueEntryEntitySavedFaker.getLeagueEntryId().getSummonerId()).get(0);
+        LeagueEntryVO leagueEntryVOFindKeria = leagueEntryService.findByLeagueEntryId_SummonerId(leagueEntryEntitySavedKeria.getLeagueEntryId().getSummonerId()).get(0);
 
         // then
-        assertThat(leagueEntryEntityFindFaker.getSummonerName()).isEqualTo("Hide on bush");
-        assertThat(leagueEntryEntityFindFaker.getLeaguePoints()).isEqualTo(1008);
-        assertThat(leagueEntryEntityFindKeria.getSummonerName()).isEqualTo("역천괴");
-        assertThat(leagueEntryEntityFindKeria.getLeaguePoints()).isEqualTo(1002);
+        assertThat(leagueEntryVOFindFaker.getSummonerName()).isEqualTo("Hide on bush");
+        assertThat(leagueEntryVOFindFaker.getLeaguePoints()).isEqualTo(1008);
+        assertThat(leagueEntryVOFindKeria.getSummonerName()).isEqualTo("역천괴");
+        assertThat(leagueEntryVOFindKeria.getLeaguePoints()).isEqualTo(1002);
     }
 }

--- a/inlol/src/test/java/dev/saariselka/inlol/service/VOMapperTest.java
+++ b/inlol/src/test/java/dev/saariselka/inlol/service/VOMapperTest.java
@@ -185,4 +185,63 @@ public class VOMapperTest {
         assertThat(ddragonVersionVO.get().getVersion()).isEqualTo(ddragonVersionEntity.get().getVersion());
         assertThat(ddragonVersionVO.get().getCurrent()).isEqualTo(ddragonVersionEntity.get().getCurrent());
     }
+
+    @Test
+    @DisplayName("Convert LeagueMiniseriesEntity To LeagueMiniseriesVO")
+    public void toLeagueMiniseriesVO(){
+        // given
+        String summonerId = "testSummonerId";
+        String queueType = "RANKED_SOLO_5x5";
+        int target = 3;
+        int wins = 2;
+        int losses = 1;
+        String progress = "Test";
+        Timestamp rrt = new Timestamp(System.currentTimeMillis());
+        LeagueMiniSeriesEntity leagueMiniSeriesEntity = new LeagueMiniSeriesEntity(new LeagueMiniSeriesId(summonerId,queueType),losses,progress,target,wins,rrt);
+
+        //when
+        LeagueMiniSeriesVO leagueMiniSeriesVO = voMapper.toLeagueMiniseriesVO(leagueMiniSeriesEntity);
+
+        //then
+        assertThat(leagueMiniSeriesVO.getSummonerId()).isEqualTo(summonerId);
+        assertThat(leagueMiniSeriesVO.getQueueType()).isEqualTo(queueType);
+        assertThat(leagueMiniSeriesVO.getTarget()).isEqualTo(target);
+        assertThat(leagueMiniSeriesVO.getWins()).isEqualTo(wins);
+        assertThat(leagueMiniSeriesVO.getLosses()).isEqualTo(losses);
+        assertThat(leagueMiniSeriesVO.getProgress()).isEqualTo(progress);
+    }
+
+    @Test
+    @DisplayName("Convert LeagueEntry Entity List To LeagueEntry VO List")
+    public void toLeagueEntryVOList() {
+
+        //given
+        String summonerId = "testSummonerId";
+        String queueType = "RANKED_SOLO_5x5";
+        String leagueId = "05fb99f4-e149-3133-a78e-821597582f9d";
+        String summonerName = "Hide on bush";
+        String tier = "CHALLENGER";
+        String ranks = "I";
+        int leaguePoints = 1008;
+        int wins = 358;
+        int losses = 309;
+        boolean hotStreak = false;
+        boolean veteran = true;
+        boolean freshBlood = false;
+        boolean inactive = false;
+        Timestamp rrt = new Timestamp(System.currentTimeMillis());
+
+        LeagueEntryEntity leagueEntryEntity = new LeagueEntryEntity(new LeagueEntryId(summonerId,queueType),leagueId,summonerName,tier,ranks,leaguePoints,wins,losses,hotStreak,
+                veteran,freshBlood,inactive,rrt);
+        List<LeagueEntryEntity> leagueEntryEntityList = new ArrayList<>();
+        leagueEntryEntityList.add(leagueEntryEntity);
+
+        //when
+        List<LeagueEntryVO> leagueEntryVOList = new ArrayList<>();
+        leagueEntryVOList = voMapper.toLeagueEntryVOList(leagueEntryEntityList);
+
+        //then
+        assertThat(leagueEntryVOList.get(0).getSummonerId()).isEqualTo(summonerId);
+        assertThat(leagueEntryVOList.get(0).getQueueType()).isEqualTo(queueType);
+    }
 }

--- a/inlol/src/test/java/dev/saariselka/inlol/vo/LeagueEntryVOTest.java
+++ b/inlol/src/test/java/dev/saariselka/inlol/vo/LeagueEntryVOTest.java
@@ -1,0 +1,102 @@
+package dev.saariselka.inlol.vo;
+
+import dev.saariselka.inlol.dto.LeagueEntryDto;
+import dev.saariselka.inlol.dto.LeagueMiniSeriesDto;
+import dev.saariselka.inlol.entity.LeagueEntryEntity;
+import dev.saariselka.inlol.entity.LeagueEntryId;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Timestamp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LeagueEntryVOTest {
+
+    @Test
+    @DisplayName("LeagueEntryVO Lombok Get Function")
+    public void testLombokGetFunction() {
+
+        // Given
+        String summonerId = "TestUser";
+        String queueType = "RANKED_SOLO_5x5";
+        String leagueId = "TestLeagueId";
+        String summonerName = "TestName";
+        String tier = "TestTier";
+        String ranks = "TestRank";
+        int leaguePoints = 50;
+        int leagueEntry_wins = 10;
+        int leagueEntry_losses = 5;
+        boolean hotStreak = false;
+        boolean veteran = false;
+        boolean freshBlood = false;
+        boolean inactive = false;
+
+        // When
+        LeagueEntryVO leagueEntryVO = new LeagueEntryVO(summonerId,queueType,leagueId,summonerName,tier,ranks,leaguePoints,leagueEntry_wins,leagueEntry_losses,hotStreak,veteran,freshBlood,inactive);
+
+        // Then
+        assertThat(leagueEntryVO.getSummonerId()).isEqualTo(summonerId);
+        assertThat(leagueEntryVO.getQueueType()).isEqualTo(queueType);
+        assertThat(leagueEntryVO.getLeagueId()).isEqualTo(leagueId);
+        assertThat(leagueEntryVO.getSummonerName()).isEqualTo(summonerName);
+        assertThat(leagueEntryVO.getTier()).isEqualTo(tier);
+        assertThat(leagueEntryVO.getRanks()).isEqualTo(ranks);
+        assertThat(leagueEntryVO.getLeaguePoints()).isEqualTo(leaguePoints);
+        assertThat(leagueEntryVO.getWins()).isEqualTo(leagueEntry_wins);
+        assertThat(leagueEntryVO.getLosses()).isEqualTo(leagueEntry_losses);
+    }
+
+    @Test
+    @DisplayName("LeagueEntryVO Lombok Set Function")
+    public void testLombokSetFunction() {
+        // Given
+        String summonerId = "TestUser";
+        String tobe_summonerId = "Tobe_TestUser";
+        String queueType = "RANKED_SOLO_5x5";
+        String tobe_queueType = "RANKED_FLEX_SR";
+
+        String leagueId = "TestLeagueId";
+        String tobe_leagueId = "tobe_TestLeagueId";
+        String summonerName = "TestName";
+        String tobe_summonerName = "tobe_TestName";
+        String tier = "TestTier";
+        String tobe_tier = "tobe_TestTier";
+        String ranks = "TestRank";
+        String tobe_ranks = "tobe_TestRank";
+        int leaguePoints = 50;
+        int tobe_leaguePoints = 51;
+        int leagueEntry_wins = 10;
+        int tobe_leagueEntry_wins = 11;
+        int leagueEntry_losses = 5;
+        int tobe_leagueEntry_losses = 6;
+        boolean hotStreak = false;
+        boolean veteran = false;
+        boolean freshBlood = false;
+        boolean inactive = false;
+
+        LeagueEntryVO leagueEntryVO = new LeagueEntryVO(summonerId,queueType,leagueId,summonerName,tier,ranks,leaguePoints,leagueEntry_wins,leagueEntry_losses,hotStreak,veteran,freshBlood,inactive);
+
+        // When
+        leagueEntryVO.setSummonerId(tobe_summonerId);
+        leagueEntryVO.setQueueType(tobe_queueType);
+        leagueEntryVO.setLeagueId(tobe_leagueId);
+        leagueEntryVO.setSummonerName(tobe_summonerName);
+        leagueEntryVO.setTier(tobe_tier);
+        leagueEntryVO.setRanks(tobe_ranks);
+        leagueEntryVO.setLeaguePoints(tobe_leaguePoints);
+        leagueEntryVO.setWins(tobe_leagueEntry_wins);
+        leagueEntryVO.setLosses(tobe_leagueEntry_losses);
+
+        // Then
+        assertThat(leagueEntryVO.getSummonerId()).isEqualTo(tobe_summonerId);
+        assertThat(leagueEntryVO.getQueueType()).isEqualTo(tobe_queueType);
+        assertThat(leagueEntryVO.getLeagueId()).isEqualTo(tobe_leagueId);
+        assertThat(leagueEntryVO.getSummonerName()).isEqualTo(tobe_summonerName);
+        assertThat(leagueEntryVO.getTier()).isEqualTo(tobe_tier);
+        assertThat(leagueEntryVO.getRanks()).isEqualTo(tobe_ranks);
+        assertThat(leagueEntryVO.getLeaguePoints()).isEqualTo(tobe_leaguePoints);
+        assertThat(leagueEntryVO.getWins()).isEqualTo(tobe_leagueEntry_wins);
+        assertThat(leagueEntryVO.getLosses()).isEqualTo(tobe_leagueEntry_losses);
+    }
+}


### PR DESCRIPTION
- new
  . LeagueEntry VO
- change
  . LeagueEntry Service, Controller, DBFacade 內 LeagueEntryEntity -> LeagueEntryDto, LeagueEntry VO 사용하도록 변경
  . Dto Mapper, VO Mapper Class 內 LeagueEntry Convert method 추가